### PR TITLE
Workflow JavaScript Sample -  Parse DQL result and trigger conditional branches

### DIFF
--- a/samples/JavaScript - Parse DQL Result and Trigger Conditional Branches/README.md
+++ b/samples/JavaScript - Parse DQL Result and Trigger Conditional Branches/README.md
@@ -9,3 +9,5 @@ For quick testing: DQL query (first task) generates dummy data with DQL â€˜dataâ
 - If production error count > 100 ---> branch Workflow into task A
 - If production error count >= 0 and <= 100 ---> branch Workflow into task B
 - If production namespace not found ---> branch Workflow into task C
+
+![image](https://github.com/Dynatrace-Tomislav/Dynatrace-workflow-samples/assets/14933193/a06ed417-acbc-4885-9bee-795f5703f2d4)

--- a/samples/JavaScript - Parse DQL Result and Trigger Conditional Branches/README.md
+++ b/samples/JavaScript - Parse DQL Result and Trigger Conditional Branches/README.md
@@ -1,0 +1,11 @@
+## Workflow JavaScript Template / Sample - How to (1) Parse DQL Result (Iterate JSON Array) and then (2) trigger conditional branches (Jinja Expression)
+
+DT Workflow template / sample that shows how to achieve the following:
+
+1) Parse the result of a DQL query in JavaScript (iterate through result JSON array).
+For quick testing: DQL query (first task) generates dummy data with DQL ‘data’ command
+
+2) Based on the the processed result from 1), then trigger conditional branches (Jinja expressions). For example: 
+- If production error count > 100 ---> branch Workflow into task A
+- If production error count >= 0 and <= 100 ---> branch Workflow into task B
+- If production namespace not found ---> branch Workflow into task C

--- a/samples/JavaScript - Parse DQL Result and Trigger Conditional Branches/README.md
+++ b/samples/JavaScript - Parse DQL Result and Trigger Conditional Branches/README.md
@@ -1,4 +1,9 @@
-## Workflow JavaScript Template / Sample - How to (1) Parse DQL Result (Iterate JSON Array) and then (2) trigger conditional branches (Jinja Expression)
+## 1) Workflow JavaScript Template / Sample - How to (1) Parse DQL Result (Iterate JSON Array) and then (2) trigger conditional branches (Jinja Expression)
+
+```
+wftpl_workflow_javascript_-_parse_dql.yaml ---> Workflow exported via 'Download/Workflow' option in DT
+wf_workflow_javascript_-_parse_dql.json ---> Workflow exported via 'Download/Template' option in DT
+```
 
 DT Workflow template / sample that shows how to achieve the following:
 
@@ -11,3 +16,14 @@ For quick testing: DQL query (first task) generates dummy data with DQL â€˜dataâ
 - If production namespace not found ---> branch Workflow into task C
 
 ![image](https://github.com/Dynatrace-Tomislav/Dynatrace-workflow-samples/assets/14933193/a06ed417-acbc-4885-9bee-795f5703f2d4)
+
+
+## 2) Workflow Template / Sample - Conditional branches (based on DQL result)
+```
+wftpl_conditions_sample.yaml ---> Workflow exported via 'Download/Workflow' option in DT
+wf_conditions_sample.json ---> Workflow exported via 'Download/Template' option in DT
+```
+
+The second template / sample is a shorter version without the JavaScript step. The DQL results are evaluated directly in the conditions of the relevant branches (see screenshot below)
+
+**Note:** While the second version (without JavaScript) basically achieves the same result, the first longer version (with JavaScript) provides a template / sample where the JavaScript task adds additional flexibility (to add more complex custom logic / processing of the DQL result in JavaScript, if needed).

--- a/samples/JavaScript - Parse DQL Result and Trigger Conditional Branches/README.md
+++ b/samples/JavaScript - Parse DQL Result and Trigger Conditional Branches/README.md
@@ -26,4 +26,6 @@ wf_conditions_sample.json ---> Workflow exported via 'Download/Template' option 
 
 The second template / sample is a shorter version without the JavaScript step. The DQL results are evaluated directly in the conditions of the relevant branches (see screenshot below)
 
+![WF_conditions_sample](https://github.com/Dynatrace-Tomislav/Dynatrace-workflow-samples/assets/14933193/c663fb74-16f7-47e6-ac14-9cace9d8f66f)
+
 **Note:** While the second version (without JavaScript) basically achieves the same result, the first longer version (with JavaScript) provides a template / sample where the JavaScript task adds additional flexibility (to add more complex custom logic / processing of the DQL result in JavaScript, if needed).

--- a/samples/JavaScript - Parse DQL Result and Trigger Conditional Branches/wf_conditions_sample.json
+++ b/samples/JavaScript - Parse DQL Result and Trigger Conditional Branches/wf_conditions_sample.json
@@ -1,0 +1,87 @@
+{
+  "id": "413b7276-627a-459b-aea5-f5e2678b0ef9",
+  "title": "Conditions sample",
+  "tasks": {
+    "if_status_ok": {
+      "name": "if_status_ok",
+      "action": "dynatrace.automations:run-javascript",
+      "description": "Build a custom task running js Code",
+      "input": {
+        "script": "// optional import of sdk modules\nimport { execution } from '@dynatrace-sdk/automation-utils';\n\nexport default async function ({ execution_id }) {\n  console.log(\"status OK\");\n}"
+      },
+      "position": {
+        "x": 0,
+        "y": 2
+      },
+      "predecessors": [
+        "execute_dql_query_1"
+      ],
+      "conditions": {
+        "states": {
+          "execute_dql_query_1": "OK"
+        },
+        "custom": "{{ result(\"execute_dql_query_1\")['records'] and (result(\"execute_dql_query_1\").records[0].error_count | int) <= 100 }}"
+      }
+    },
+    "execute_dql_query_1": {
+      "name": "execute_dql_query_1",
+      "action": "dynatrace.automations:execute-dql-query",
+      "description": "Executes DQL query",
+      "input": {
+        "query": "data record(k8s.namespace.name = \"easyTravel\", error_count = 456),\n     record(k8s.namespace.name = \"default\", error_count = 789),\n     record(k8s.namespace.name = \"production\", error_count = 190)\n| filter k8s.namespace.name == \"production\""
+      },
+      "position": {
+        "x": 0,
+        "y": 1
+      },
+      "predecessors": []
+    },
+    "if_status_high_error_count": {
+      "name": "if_status_high_error_count",
+      "action": "dynatrace.automations:run-javascript",
+      "description": "Build a custom task running js Code",
+      "input": {
+        "script": "export default async function ({ execution_id }) {\n    console.log('in Status high error count branch');\n}"
+      },
+      "position": {
+        "x": -1,
+        "y": 2
+      },
+      "predecessors": [
+        "execute_dql_query_1"
+      ],
+      "conditions": {
+        "states": {
+          "execute_dql_query_1": "OK"
+        },
+        "custom": "{{ result(\"execute_dql_query_1\")['records'] and (result(\"execute_dql_query_1\").records[0].error_count | int) > 100 }}"
+      }
+    },
+    "if_status_k8s_ns_not_found": {
+      "name": "if_status_k8s_ns_not_found",
+      "action": "dynatrace.automations:run-javascript",
+      "description": "Build a custom task running js Code",
+      "input": {
+        "script": "// optional import of sdk modules\nimport { execution } from '@dynatrace-sdk/automation-utils';\n\nexport default async function ({ execution_id }) {\n  console.log('Not found');\n}"
+      },
+      "position": {
+        "x": 1,
+        "y": 2
+      },
+      "predecessors": [
+        "execute_dql_query_1"
+      ],
+      "conditions": {
+        "states": {
+          "execute_dql_query_1": "OK"
+        },
+        "custom": "{{ not result(\"execute_dql_query_1\")['records'] }}"
+      }
+    }
+  },
+  "description": "",
+  "ownerType": "USER",
+  "isPrivate": true,
+  "trigger": {},
+  "schemaVersion": 3
+}

--- a/samples/JavaScript - Parse DQL Result and Trigger Conditional Branches/wf_workflow_javascript_-_parse_dql.json
+++ b/samples/JavaScript - Parse DQL Result and Trigger Conditional Branches/wf_workflow_javascript_-_parse_dql.json
@@ -1,0 +1,106 @@
+{
+  "title": "Workflow JavaScript - Parse DQL Result & Conditional Branch",
+  "description": "",
+  "tasks": {
+    "if_status_ok": {
+      "name": "if_status_ok",
+      "description": "If production error count >= 0 and <= 100",
+      "action": "dynatrace.automations:run-javascript",
+      "input": {
+        "script": "// optional import of sdk modules\nimport { execution } from '@dynatrace-sdk/automation-utils';\n\nexport default async function ({ execution_id }) {\n  // your code goes here\n  // e.g. get the current execution\n  const ex = await execution(execution_id);\n  console.log('in OK branch');\n\n  return { triggeredBy: ex.trigger };\n}"
+      },
+      "position": {
+        "x": 0,
+        "y": 3
+      },
+      "predecessors": [
+        "process_dql_result"
+      ],
+      "conditions": {
+        "states": {
+          "process_dql_result": "OK"
+        },
+        "custom": "{{ result('process_dql_result').ret_status == \"Status-OK\"}}"
+      }
+    },
+    "dql_get_k8s_errors": {
+      "name": "dql_get_k8s_errors",
+      "description": "DQL to get error count by K8s namespace",
+      "action": "dynatrace.automations:execute-dql-query",
+      "input": {
+        "query": "data record(k8s.namespace.name = \"easyTravel\", error_count = 456),\n     record(k8s.namespace.name = \"default\", error_count = 789),\n     record(k8s.namespace.name = \"production\", error_count = 90)\n// | filter k8s.namespace.name == \"production\"\n\n/*\nAbove DQL 'data' command generates sample data during query runtime. It is intended to test and document query scenarios based on a small, exemplary dataset. \nThis makes it a lot easier to generate instant test (dummy) data test for the following Workflow.\nAbove DQL query can also be run in a Notebook. Result:\n\n  k8s.namespace.name       | error_count\n  -------------------------|---------\n  easyTravel               | 456\n  default                  | 789\n  production               | 100\n\nTo test the 3 scenarios of this Workflow, simply update field 'error_count' for k8s namespace 'production' and run the Workflow. Example:\n- If production error count > 100 ---> Workflow ends in branch 'if_status_high_error_count'\n- If production error count between 0 and 100 ---> Workflow ends in branch 'if_status_ok'\n- If k8s namespace 'production' does not exist ---> Workflow ends in branch 'if_status_k8s_ns_not_found'\n\n\nIn a real world scenario, an equivalent DQL query could be as follows:\n\nfetch logs, from:now() - 1h\n| filter loglevel ==\"ERROR\" and isNotNull(k8s.namespace.name)\n| summarize error_count=count(), by:{k8s.namespace.name}\n| sort error_count desc\n| limit 3\n\n*/"
+      },
+      "position": {
+        "x": 0,
+        "y": 1
+      },
+      "predecessors": []
+    },
+    "process_dql_result": {
+      "name": "process_dql_result",
+      "description": "Process result of DQL query (from previous task)",
+      "action": "dynatrace.automations:run-javascript",
+      "input": {
+        "script": "// optional import of sdk modules\nimport { execution } from '@dynatrace-sdk/automation-utils';\n\nexport default async function ({ execution_id }) {\n\n  // --------------------------------------------\n  // Step 1) Get result from previous DQL task\n  // --------------------------------------------\n  console.log(\"get result from previous task...\");\n  var task_info = await fetch(`/platform/automation/v1/executions/${execution_id}/tasks/dql_get_k8s_errors`);\n  var result_json_array = await task_info.json();\n  console.log(\"result_json_array\");\n  console.log(result_json_array);\n  console.log(\"------------------------------\");\n  \n  /* \n  DQL result returns (from previous step) returns 3 result rows. Example:\n  \n  k8s.namespace.name       | error_count\n  -------------------------|---------\n  easyTravel               | 456\n  default                  | 789\n  production               | 100\n\n  in JSON format:\n  \n  records: [\n     { error_count: \"456\", \"k8s.namespace.name\": \"easyTravel\" },\n     { error_count: \"789\", \"k8s.namespace.name\": \"default\" },\n     { error_count: \"90\", \"k8s.namespace.name\": \"production\" }\n  ],\n  */\n  \n\n  var production_error_count = -1;\n  // --------------------------------------------\n  // Step 2) - Option 1) From JSON result array: Assign to JavaScript variable\n  // \n  // Easiest option: Filter first DQL to Production namespace only (see example),\n  // meaning there will only be 1 result record which makes it easier and you don't have to iterate through the JSON array\n  // -------------------------------------------- \n  // var production_error_count = result_json_array.result.records[0]['error_count'];\n  // var k8s_namespace = result_json_array.result.records[0]['k8s.namespace.name'];\n  // console.log(\"production_error_count\");\n  // console.log(production_error_count);\n  // console.log(\"k8s_namespace\");\n  // console.log(k8s_namespace);\n  // console.log(\"************************\");\n\n  \n  // --------------------------------------------\n  // Step 2) - Option 2) From JSON result array: Iterate through JSON array\n  // \n  // Iterate through JSON array and find k8s namespace with value \"production\" \n  // Option if there are more than 1 result record, compared to above Step 2) - Option 1)\n  // -------------------------------------------- \n  var i = 0;\n\n  while (i < result_json_array.result.records.length) {\n    var k8s_namespace = result_json_array.result.records[i]['k8s.namespace.name'];\n    console.log(\"k8s_namespace: \" + k8s_namespace);\n\n    if (k8s_namespace === \"production\"){\n      console.log(\"production k8s namespace found!\");\n      production_error_count = result_json_array.result.records[i]['error_count'];\n    }\n    \n    i++;\n  }\n\n  // --------------------------------------------\n  // Step 3) - Return status, depending on # of errors. Possible scenarios:\n  //\n  //    Scenario                                   | Status\n  //    -------------------------------------------|---------------\n  //    production error count >= 100              | Status-High-Error-Count\n  //    production error count between 0 and 100   | Status-OK\n  //    production k8s namespace not found         | Status-K8s-Prod-Namespace-Not-Found\n  //\n  // -------------------------------------------- \n\n\n  console.log(\"production_error_count: \" + production_error_count);\n\n  var status = null;\n\n  if (production_error_count > 100 ){\n    console.log(\"state NOT OK ---> high error count\");\n    status = \"Status-High-Error-Count\";\n  } \n  else if (production_error_count >= 0 && production_error_count <= 100){\n    console.log(\"state OK ---> errors between 0 and 100\");\n    status = \"Status-OK\";\n  }\n  else {\n    console.log(\"state Error ---> K8s production namespace not found\");\n    status = \"Status-K8s-Prod-Namespace-Not-Found\";\n  }\n\n  console.log(\"status: \" + status);\n\n  return {\n    ret_status: status,\n    ret_production_error_count: production_error_count\n  };\n\n}"
+      },
+      "position": {
+        "x": 0,
+        "y": 2
+      },
+      "predecessors": [
+        "dql_get_k8s_errors"
+      ],
+      "conditions": {
+        "states": {
+          "dql_get_k8s_errors": "OK"
+        }
+      }
+    },
+    "if_status_high_error_count": {
+      "name": "if_status_high_error_count",
+      "description": "If production error count > 100 ",
+      "action": "dynatrace.automations:run-javascript",
+      "input": {
+        "script": "// optional import of sdk modules\nimport { execution } from '@dynatrace-sdk/automation-utils';\n\nexport default async function ({ execution_id }) {\n  // your code goes here\n  // e.g. get the current execution\n  const ex = await execution(execution_id);\n  console.log('in Status high error count branch');\n\n  return { triggeredBy: ex.trigger };\n}"
+      },
+      "position": {
+        "x": -1,
+        "y": 3
+      },
+      "predecessors": [
+        "process_dql_result"
+      ],
+      "conditions": {
+        "states": {
+          "process_dql_result": "OK"
+        },
+        "custom": "{{ result('process_dql_result').ret_status == \"Status-High-Error-Count\"}}"
+      }
+    },
+    "if_status_k8s_ns_not_found": {
+      "name": "if_status_k8s_ns_not_found",
+      "description": "If production namespace not found",
+      "action": "dynatrace.automations:run-javascript",
+      "input": {
+        "script": "// optional import of sdk modules\nimport { execution } from '@dynatrace-sdk/automation-utils';\n\nexport default async function ({ execution_id }) {\n  // your code goes here\n  // e.g. get the current execution\n  const ex = await execution(execution_id);\n  console.log('Automated script execution on behalf of', ex.trigger);\n\n  return { triggeredBy: ex.trigger };\n}"
+      },
+      "position": {
+        "x": 1,
+        "y": 3
+      },
+      "predecessors": [
+        "process_dql_result"
+      ],
+      "conditions": {
+        "states": {
+          "process_dql_result": "OK"
+        },
+        "custom": "{{ result('process_dql_result').ret_status == \"Status-K8s-Prod-Namespace-Not-Found\"}}"
+      }
+    }
+  },
+  "ownerType": "USER",
+  "isPrivate": true,
+  "trigger": {},
+  "schemaVersion": 3
+}

--- a/samples/JavaScript - Parse DQL Result and Trigger Conditional Branches/wf_workflow_javascript_-_parse_dql.json
+++ b/samples/JavaScript - Parse DQL Result and Trigger Conditional Branches/wf_workflow_javascript_-_parse_dql.json
@@ -1,11 +1,11 @@
 {
+  "id": "40073020-d6b6-4b2a-b67c-abe53811fe8a",
   "title": "Workflow JavaScript - Parse DQL Result & Conditional Branch",
-  "description": "",
   "tasks": {
     "if_status_ok": {
       "name": "if_status_ok",
-      "description": "If production error count >= 0 and <= 100",
       "action": "dynatrace.automations:run-javascript",
+      "description": "If production error count >= 0 and <= 100",
       "input": {
         "script": "// optional import of sdk modules\nimport { execution } from '@dynatrace-sdk/automation-utils';\n\nexport default async function ({ execution_id }) {\n  // your code goes here\n  // e.g. get the current execution\n  const ex = await execution(execution_id);\n  console.log('in OK branch');\n\n  return { triggeredBy: ex.trigger };\n}"
       },
@@ -25,8 +25,8 @@
     },
     "dql_get_k8s_errors": {
       "name": "dql_get_k8s_errors",
-      "description": "DQL to get error count by K8s namespace",
       "action": "dynatrace.automations:execute-dql-query",
+      "description": "DQL to get error count by K8s namespace",
       "input": {
         "query": "data record(k8s.namespace.name = \"easyTravel\", error_count = 456),\n     record(k8s.namespace.name = \"default\", error_count = 789),\n     record(k8s.namespace.name = \"production\", error_count = 90)\n// | filter k8s.namespace.name == \"production\"\n\n/*\nAbove DQL 'data' command generates sample data during query runtime. It is intended to test and document query scenarios based on a small, exemplary dataset. \nThis makes it a lot easier to generate instant test (dummy) data test for the following Workflow.\nAbove DQL query can also be run in a Notebook. Result:\n\n  k8s.namespace.name       | error_count\n  -------------------------|---------\n  easyTravel               | 456\n  default                  | 789\n  production               | 100\n\nTo test the 3 scenarios of this Workflow, simply update field 'error_count' for k8s namespace 'production' and run the Workflow. Example:\n- If production error count > 100 ---> Workflow ends in branch 'if_status_high_error_count'\n- If production error count between 0 and 100 ---> Workflow ends in branch 'if_status_ok'\n- If k8s namespace 'production' does not exist ---> Workflow ends in branch 'if_status_k8s_ns_not_found'\n\n\nIn a real world scenario, an equivalent DQL query could be as follows:\n\nfetch logs, from:now() - 1h\n| filter loglevel ==\"ERROR\" and isNotNull(k8s.namespace.name)\n| summarize error_count=count(), by:{k8s.namespace.name}\n| sort error_count desc\n| limit 3\n\n*/"
       },
@@ -38,10 +38,10 @@
     },
     "process_dql_result": {
       "name": "process_dql_result",
-      "description": "Process result of DQL query (from previous task)",
       "action": "dynatrace.automations:run-javascript",
+      "description": "Process result of DQL query (from previous task)",
       "input": {
-        "script": "// optional import of sdk modules\nimport { execution } from '@dynatrace-sdk/automation-utils';\n\nexport default async function ({ execution_id }) {\n\n  // --------------------------------------------\n  // Step 1) Get result from previous DQL task\n  // --------------------------------------------\n  console.log(\"get result from previous task...\");\n  var task_info = await fetch(`/platform/automation/v1/executions/${execution_id}/tasks/dql_get_k8s_errors`);\n  var result_json_array = await task_info.json();\n  console.log(\"result_json_array\");\n  console.log(result_json_array);\n  console.log(\"------------------------------\");\n  \n  /* \n  DQL result returns (from previous step) returns 3 result rows. Example:\n  \n  k8s.namespace.name       | error_count\n  -------------------------|---------\n  easyTravel               | 456\n  default                  | 789\n  production               | 100\n\n  in JSON format:\n  \n  records: [\n     { error_count: \"456\", \"k8s.namespace.name\": \"easyTravel\" },\n     { error_count: \"789\", \"k8s.namespace.name\": \"default\" },\n     { error_count: \"90\", \"k8s.namespace.name\": \"production\" }\n  ],\n  */\n  \n\n  var production_error_count = -1;\n  // --------------------------------------------\n  // Step 2) - Option 1) From JSON result array: Assign to JavaScript variable\n  // \n  // Easiest option: Filter first DQL to Production namespace only (see example),\n  // meaning there will only be 1 result record which makes it easier and you don't have to iterate through the JSON array\n  // -------------------------------------------- \n  // var production_error_count = result_json_array.result.records[0]['error_count'];\n  // var k8s_namespace = result_json_array.result.records[0]['k8s.namespace.name'];\n  // console.log(\"production_error_count\");\n  // console.log(production_error_count);\n  // console.log(\"k8s_namespace\");\n  // console.log(k8s_namespace);\n  // console.log(\"************************\");\n\n  \n  // --------------------------------------------\n  // Step 2) - Option 2) From JSON result array: Iterate through JSON array\n  // \n  // Iterate through JSON array and find k8s namespace with value \"production\" \n  // Option if there are more than 1 result record, compared to above Step 2) - Option 1)\n  // -------------------------------------------- \n  var i = 0;\n\n  while (i < result_json_array.result.records.length) {\n    var k8s_namespace = result_json_array.result.records[i]['k8s.namespace.name'];\n    console.log(\"k8s_namespace: \" + k8s_namespace);\n\n    if (k8s_namespace === \"production\"){\n      console.log(\"production k8s namespace found!\");\n      production_error_count = result_json_array.result.records[i]['error_count'];\n    }\n    \n    i++;\n  }\n\n  // --------------------------------------------\n  // Step 3) - Return status, depending on # of errors. Possible scenarios:\n  //\n  //    Scenario                                   | Status\n  //    -------------------------------------------|---------------\n  //    production error count >= 100              | Status-High-Error-Count\n  //    production error count between 0 and 100   | Status-OK\n  //    production k8s namespace not found         | Status-K8s-Prod-Namespace-Not-Found\n  //\n  // -------------------------------------------- \n\n\n  console.log(\"production_error_count: \" + production_error_count);\n\n  var status = null;\n\n  if (production_error_count > 100 ){\n    console.log(\"state NOT OK ---> high error count\");\n    status = \"Status-High-Error-Count\";\n  } \n  else if (production_error_count >= 0 && production_error_count <= 100){\n    console.log(\"state OK ---> errors between 0 and 100\");\n    status = \"Status-OK\";\n  }\n  else {\n    console.log(\"state Error ---> K8s production namespace not found\");\n    status = \"Status-K8s-Prod-Namespace-Not-Found\";\n  }\n\n  console.log(\"status: \" + status);\n\n  return {\n    ret_status: status,\n    ret_production_error_count: production_error_count\n  };\n\n}"
+        "script": "// optional import of sdk modules\nimport { execution } from '@dynatrace-sdk/automation-utils';\n\nexport default async function ({ execution_id }) {\n\n  // --------------------------------------------\n  // Step 1) Get result from previous DQL task\n  // --------------------------------------------\n  console.log(\"get result from previous task...\");\n  const exe = await execution(execution_id);\n  const result_json_array = await exe.result(\"dql_get_k8s_errors\");\n  console.log(\"result_json_array\");\n  console.log(result_json_array); \n  console.log(\"------------------------------\");\n  \n  /* \n  DQL result returns (from previous step) returns 3 result rows. Example:\n  \n  k8s.namespace.name       | error_count\n  -------------------------|---------\n  easyTravel               | 456\n  default                  | 789\n  production               | 100\n\n  in JSON format:\n  \n  records: [\n     { error_count: \"456\", \"k8s.namespace.name\": \"easyTravel\" },\n     { error_count: \"789\", \"k8s.namespace.name\": \"default\" },\n     { error_count: \"90\", \"k8s.namespace.name\": \"production\" }\n  ],\n  */\n  \n\n  var production_error_count = -1;\n  // --------------------------------------------\n  // Step 2) - Option 1) From JSON result array: Assign to JavaScript variable\n  // \n  // Easiest option: Filter first DQL to Production namespace only (see example),\n  // meaning there will only be 1 result record which makes it easier and you don't have to iterate through the JSON array\n  // -------------------------------------------- \n  // var production_error_count = result_json_array.records[0]['error_count'];\n  // var k8s_namespace = result_json_array.records[0]['k8s.namespace.name'];\n  // console.log(\"production_error_count\");\n  // console.log(production_error_count);\n  // console.log(\"k8s_namespace\");\n  // console.log(k8s_namespace);\n  // console.log(\"************************\");\n\n  \n  // --------------------------------------------\n  // Step 2) - Option 2) From JSON result array: Iterate through JSON array\n  // \n  // Iterate through JSON array and find k8s namespace with value \"production\" \n  // Option if there are more than 1 result record, compared to above Step 2) - Option 1)\n  // -------------------------------------------- \n  var i = 0;\n\n  while (i < result_json_array.records.length) {\n    var k8s_namespace = result_json_array.records[i]['k8s.namespace.name'];\n    console.log(\"k8s_namespace: \" + k8s_namespace);\n\n    if (k8s_namespace === \"production\"){\n      console.log(\"production k8s namespace found!\");\n      production_error_count = result_json_array.records[i]['error_count'];\n    }\n    \n    i++;\n  }\n\n  // --------------------------------------------\n  // Step 3) - Return status, depending on # of errors. Possible scenarios:\n  //\n  //    Scenario                                   | Status\n  //    -------------------------------------------|---------------\n  //    production error count >= 100              | Status-High-Error-Count\n  //    production error count between 0 and 100   | Status-OK\n  //    production k8s namespace not found         | Status-K8s-Prod-Namespace-Not-Found\n  //\n  // -------------------------------------------- \n\n\n  console.log(\"production_error_count: \" + production_error_count);\n\n  var status = null;\n\n  if (production_error_count > 100 ){\n    console.log(\"state NOT OK ---> high error count\");\n    status = \"Status-High-Error-Count\";\n  } \n  else if (production_error_count >= 0 && production_error_count <= 100){\n    console.log(\"state OK ---> errors between 0 and 100\");\n    status = \"Status-OK\";\n  }\n  else {\n    console.log(\"state Error ---> K8s production namespace not found\");\n    status = \"Status-K8s-Prod-Namespace-Not-Found\";\n  }\n\n  console.log(\"status: \" + status);\n\n  return {\n    ret_status: status,\n    ret_production_error_count: production_error_count\n  };\n\n}"
       },
       "position": {
         "x": 0,
@@ -58,8 +58,8 @@
     },
     "if_status_high_error_count": {
       "name": "if_status_high_error_count",
-      "description": "If production error count > 100 ",
       "action": "dynatrace.automations:run-javascript",
+      "description": "If production error count > 100 ",
       "input": {
         "script": "// optional import of sdk modules\nimport { execution } from '@dynatrace-sdk/automation-utils';\n\nexport default async function ({ execution_id }) {\n  // your code goes here\n  // e.g. get the current execution\n  const ex = await execution(execution_id);\n  console.log('in Status high error count branch');\n\n  return { triggeredBy: ex.trigger };\n}"
       },
@@ -79,8 +79,8 @@
     },
     "if_status_k8s_ns_not_found": {
       "name": "if_status_k8s_ns_not_found",
-      "description": "If production namespace not found",
       "action": "dynatrace.automations:run-javascript",
+      "description": "If production namespace not found",
       "input": {
         "script": "// optional import of sdk modules\nimport { execution } from '@dynatrace-sdk/automation-utils';\n\nexport default async function ({ execution_id }) {\n  // your code goes here\n  // e.g. get the current execution\n  const ex = await execution(execution_id);\n  console.log('Automated script execution on behalf of', ex.trigger);\n\n  return { triggeredBy: ex.trigger };\n}"
       },
@@ -99,6 +99,7 @@
       }
     }
   },
+  "description": "",
   "ownerType": "USER",
   "isPrivate": true,
   "trigger": {},

--- a/samples/JavaScript - Parse DQL Result and Trigger Conditional Branches/wftpl_conditions_sample.yaml
+++ b/samples/JavaScript - Parse DQL Result and Trigger Conditional Branches/wftpl_conditions_sample.yaml
@@ -1,0 +1,90 @@
+metadata:
+  version: "1"
+  dependencies:
+    apps:
+      - id: dynatrace.automations
+  inputs: []
+workflow:
+  title: Conditions sample
+  tasks:
+    if_status_ok:
+      name: if_status_ok
+      description: Build a custom task running js Code
+      action: dynatrace.automations:run-javascript
+      input:
+        script: |-
+          // optional import of sdk modules
+          import { execution } from '@dynatrace-sdk/automation-utils';
+
+          export default async function ({ execution_id }) {
+            console.log("status OK");
+          }
+      position:
+        x: 0
+        y: 2
+      predecessors:
+        - execute_dql_query_1
+      conditions:
+        states:
+          execute_dql_query_1: OK
+        custom: "{{ result(\"execute_dql_query_1\")['records'] and
+          (result(\"execute_dql_query_1\").records[0].error_count | int) <= 100
+          }}"
+    execute_dql_query_1:
+      name: execute_dql_query_1
+      description: Executes DQL query
+      action: dynatrace.automations:execute-dql-query
+      input:
+        query: |-
+          data record(k8s.namespace.name = "easyTravel", error_count = 456),
+               record(k8s.namespace.name = "default", error_count = 789),
+               record(k8s.namespace.name = "production", error_count = 90)
+          | filter k8s.namespace.name == "production"
+      position:
+        x: 0
+        y: 1
+      predecessors: []
+    if_status_high_error_count:
+      name: if_status_high_error_count
+      description: Build a custom task running js Code
+      action: dynatrace.automations:run-javascript
+      input:
+        script: |-
+          export default async function ({ execution_id }) {
+              console.log('in Status high error count branch');
+          }
+      position:
+        x: -1
+        y: 2
+      predecessors:
+        - execute_dql_query_1
+      conditions:
+        states:
+          execute_dql_query_1: OK
+        custom: "{{ result(\"execute_dql_query_1\")['records'] and
+          (result(\"execute_dql_query_1\").records[0].error_count | int) > 100
+          }}"
+    if_status_k8s_ns_not_found:
+      name: if_status_k8s_ns_not_found
+      description: Build a custom task running js Code
+      action: dynatrace.automations:run-javascript
+      input:
+        script: |-
+          // optional import of sdk modules
+          import { execution } from '@dynatrace-sdk/automation-utils';
+
+          export default async function ({ execution_id }) {
+            console.log('Not found');
+          }
+      position:
+        x: 1
+        y: 2
+      predecessors:
+        - execute_dql_query_1
+      conditions:
+        states:
+          execute_dql_query_1: OK
+        custom: "{{ not result(\"execute_dql_query_1\")['records'] }}"
+  description: ""
+  trigger: {}
+  schemaVersion: 3

--- a/samples/JavaScript - Parse DQL Result and Trigger Conditional Branches/wftpl_workflow_javascript_-_parse_dql.yaml
+++ b/samples/JavaScript - Parse DQL Result and Trigger Conditional Branches/wftpl_workflow_javascript_-_parse_dql.yaml
@@ -1,0 +1,270 @@
+metadata:
+  version: "1"
+  dependencies:
+    apps:
+      - id: dynatrace.automations
+  inputs: []
+workflow:
+  title: Workflow JavaScript - Parse DQL Result & Conditional Branch
+  tasks:
+    if_status_ok:
+      name: if_status_ok
+      description: If production error count >= 0 and <= 100
+      action: dynatrace.automations:run-javascript
+      input:
+        script: |-
+          // optional import of sdk modules
+          import { execution } from '@dynatrace-sdk/automation-utils';
+
+          export default async function ({ execution_id }) {
+            // your code goes here
+            // e.g. get the current execution
+            const ex = await execution(execution_id);
+            console.log('in OK branch');
+
+            return { triggeredBy: ex.trigger };
+          }
+      position:
+        x: 0
+        y: 3
+      predecessors:
+        - process_dql_result
+      conditions:
+        states:
+          process_dql_result: OK
+        custom: "{{ result('process_dql_result').ret_status == \"Status-OK\"}}"
+    dql_get_k8s_errors:
+      name: dql_get_k8s_errors
+      description: DQL to get error count by K8s namespace
+      action: dynatrace.automations:execute-dql-query
+      input:
+        query: >-
+          data record(k8s.namespace.name = "easyTravel", error_count = 456),
+               record(k8s.namespace.name = "default", error_count = 789),
+               record(k8s.namespace.name = "production", error_count = 90)
+          // | filter k8s.namespace.name == "production"
+
+
+          /*
+
+          Above DQL 'data' command generates sample data during query runtime. It is intended to test and document query scenarios based on a small, exemplary dataset. 
+
+          This makes it a lot easier to generate instant test (dummy) data test for the following Workflow.
+
+          Above DQL query can also be run in a Notebook. Result:
+
+            k8s.namespace.name       | error_count
+            -------------------------|---------
+            easyTravel               | 456
+            default                  | 789
+            production               | 100
+
+          To test the 3 scenarios of this Workflow, simply update field 'error_count' for k8s namespace 'production' and run the Workflow. Example:
+
+          - If production error count > 100 ---> Workflow ends in branch 'if_status_high_error_count'
+
+          - If production error count between 0 and 100 ---> Workflow ends in branch 'if_status_ok'
+
+          - If k8s namespace 'production' does not exist ---> Workflow ends in branch 'if_status_k8s_ns_not_found'
+
+
+
+          In a real world scenario, an equivalent DQL query could be as follows:
+
+
+          fetch logs, from:now() - 1h
+
+          | filter loglevel =="ERROR" and isNotNull(k8s.namespace.name)
+
+          | summarize error_count=count(), by:{k8s.namespace.name}
+
+          | sort error_count desc
+
+          | limit 3
+
+
+          */
+      position:
+        x: 0
+        y: 1
+      predecessors: []
+    process_dql_result:
+      name: process_dql_result
+      description: Process result of DQL query (from previous task)
+      action: dynatrace.automations:run-javascript
+      input:
+        script: >-
+          // optional import of sdk modules
+
+          import { execution } from '@dynatrace-sdk/automation-utils';
+
+
+          export default async function ({ execution_id }) {
+
+            // --------------------------------------------
+            // Step 1) Get result from previous DQL task
+            // --------------------------------------------
+            console.log("get result from previous task...");
+            var task_info = await fetch(`/platform/automation/v1/executions/${execution_id}/tasks/dql_get_k8s_errors`);
+            var result_json_array = await task_info.json();
+            console.log("result_json_array");
+            console.log(result_json_array);
+            console.log("------------------------------");
+            
+            /* 
+            DQL result returns (from previous step) returns 3 result rows. Example:
+            
+            k8s.namespace.name       | error_count
+            -------------------------|---------
+            easyTravel               | 456
+            default                  | 789
+            production               | 100
+
+            in JSON format:
+            
+            records: [
+               { error_count: "456", "k8s.namespace.name": "easyTravel" },
+               { error_count: "789", "k8s.namespace.name": "default" },
+               { error_count: "90", "k8s.namespace.name": "production" }
+            ],
+            */
+            
+
+            var production_error_count = -1;
+            // --------------------------------------------
+            // Step 2) - Option 1) From JSON result array: Assign to JavaScript variable
+            // 
+            // Easiest option: Filter first DQL to Production namespace only (see example),
+            // meaning there will only be 1 result record which makes it easier and you don't have to iterate through the JSON array
+            // -------------------------------------------- 
+            // var production_error_count = result_json_array.result.records[0]['error_count'];
+            // var k8s_namespace = result_json_array.result.records[0]['k8s.namespace.name'];
+            // console.log("production_error_count");
+            // console.log(production_error_count);
+            // console.log("k8s_namespace");
+            // console.log(k8s_namespace);
+            // console.log("************************");
+
+            
+            // --------------------------------------------
+            // Step 2) - Option 2) From JSON result array: Iterate through JSON array
+            // 
+            // Iterate through JSON array and find k8s namespace with value "production" 
+            // Option if there are more than 1 result record, compared to above Step 2) - Option 1)
+            // -------------------------------------------- 
+            var i = 0;
+
+            while (i < result_json_array.result.records.length) {
+              var k8s_namespace = result_json_array.result.records[i]['k8s.namespace.name'];
+              console.log("k8s_namespace: " + k8s_namespace);
+
+              if (k8s_namespace === "production"){
+                console.log("production k8s namespace found!");
+                production_error_count = result_json_array.result.records[i]['error_count'];
+              }
+              
+              i++;
+            }
+
+            // --------------------------------------------
+            // Step 3) - Return status, depending on # of errors. Possible scenarios:
+            //
+            //    Scenario                                   | Status
+            //    -------------------------------------------|---------------
+            //    production error count >= 100              | Status-High-Error-Count
+            //    production error count between 0 and 100   | Status-OK
+            //    production k8s namespace not found         | Status-K8s-Prod-Namespace-Not-Found
+            //
+            // -------------------------------------------- 
+
+
+            console.log("production_error_count: " + production_error_count);
+
+            var status = null;
+
+            if (production_error_count > 100 ){
+              console.log("state NOT OK ---> high error count");
+              status = "Status-High-Error-Count";
+            } 
+            else if (production_error_count >= 0 && production_error_count <= 100){
+              console.log("state OK ---> errors between 0 and 100");
+              status = "Status-OK";
+            }
+            else {
+              console.log("state Error ---> K8s production namespace not found");
+              status = "Status-K8s-Prod-Namespace-Not-Found";
+            }
+
+            console.log("status: " + status);
+
+            return {
+              ret_status: status,
+              ret_production_error_count: production_error_count
+            };
+
+          }
+      position:
+        x: 0
+        y: 2
+      predecessors:
+        - dql_get_k8s_errors
+      conditions:
+        states:
+          dql_get_k8s_errors: OK
+    if_status_high_error_count:
+      name: if_status_high_error_count
+      description: "If production error count > 100 "
+      action: dynatrace.automations:run-javascript
+      input:
+        script: |-
+          // optional import of sdk modules
+          import { execution } from '@dynatrace-sdk/automation-utils';
+
+          export default async function ({ execution_id }) {
+            // your code goes here
+            // e.g. get the current execution
+            const ex = await execution(execution_id);
+            console.log('in Status high error count branch');
+
+            return { triggeredBy: ex.trigger };
+          }
+      position:
+        x: -1
+        y: 3
+      predecessors:
+        - process_dql_result
+      conditions:
+        states:
+          process_dql_result: OK
+        custom: "{{ result('process_dql_result').ret_status ==
+          \"Status-High-Error-Count\"}}"
+    if_status_k8s_ns_not_found:
+      name: if_status_k8s_ns_not_found
+      description: If production namespace not found
+      action: dynatrace.automations:run-javascript
+      input:
+        script: |-
+          // optional import of sdk modules
+          import { execution } from '@dynatrace-sdk/automation-utils';
+
+          export default async function ({ execution_id }) {
+            // your code goes here
+            // e.g. get the current execution
+            const ex = await execution(execution_id);
+            console.log('Automated script execution on behalf of', ex.trigger);
+
+            return { triggeredBy: ex.trigger };
+          }
+      position:
+        x: 1
+        y: 3
+      predecessors:
+        - process_dql_result
+      conditions:
+        states:
+          process_dql_result: OK
+        custom: "{{ result('process_dql_result').ret_status ==
+          \"Status-K8s-Prod-Namespace-Not-Found\"}}"
+  description: ""
+  trigger: {}
+  schemaVersion: 3

--- a/samples/JavaScript - Parse DQL Result and Trigger Conditional Branches/wftpl_workflow_javascript_-_parse_dql.yaml
+++ b/samples/JavaScript - Parse DQL Result and Trigger Conditional Branches/wftpl_workflow_javascript_-_parse_dql.yaml
@@ -47,9 +47,12 @@ workflow:
 
           /*
 
-          Above DQL 'data' command generates sample data during query runtime. It is intended to test and document query scenarios based on a small, exemplary dataset. 
+          Above DQL 'data' command generates sample data during query runtime.
+          It is intended to test and document query scenarios based on a small,
+          exemplary dataset. 
 
-          This makes it a lot easier to generate instant test (dummy) data test for the following Workflow.
+          This makes it a lot easier to generate instant test (dummy) data test
+          for the following Workflow.
 
           Above DQL query can also be run in a Notebook. Result:
 
@@ -59,13 +62,18 @@ workflow:
             default                  | 789
             production               | 100
 
-          To test the 3 scenarios of this Workflow, simply update field 'error_count' for k8s namespace 'production' and run the Workflow. Example:
+          To test the 3 scenarios of this Workflow, simply update field
+          'error_count' for k8s namespace 'production' and run the Workflow.
+          Example:
 
-          - If production error count > 100 ---> Workflow ends in branch 'if_status_high_error_count'
+          - If production error count > 100 ---> Workflow ends in branch
+          'if_status_high_error_count'
 
-          - If production error count between 0 and 100 ---> Workflow ends in branch 'if_status_ok'
+          - If production error count between 0 and 100 ---> Workflow ends in
+          branch 'if_status_ok'
 
-          - If k8s namespace 'production' does not exist ---> Workflow ends in branch 'if_status_k8s_ns_not_found'
+          - If k8s namespace 'production' does not exist ---> Workflow ends in
+          branch 'if_status_k8s_ns_not_found'
 
 
 
@@ -105,10 +113,10 @@ workflow:
             // Step 1) Get result from previous DQL task
             // --------------------------------------------
             console.log("get result from previous task...");
-            var task_info = await fetch(`/platform/automation/v1/executions/${execution_id}/tasks/dql_get_k8s_errors`);
-            var result_json_array = await task_info.json();
+            const exe = await execution(execution_id);
+            const result_json_array = await exe.result("dql_get_k8s_errors");
             console.log("result_json_array");
-            console.log(result_json_array);
+            console.log(result_json_array); 
             console.log("------------------------------");
             
             /* 
@@ -137,8 +145,8 @@ workflow:
             // Easiest option: Filter first DQL to Production namespace only (see example),
             // meaning there will only be 1 result record which makes it easier and you don't have to iterate through the JSON array
             // -------------------------------------------- 
-            // var production_error_count = result_json_array.result.records[0]['error_count'];
-            // var k8s_namespace = result_json_array.result.records[0]['k8s.namespace.name'];
+            // var production_error_count = result_json_array.records[0]['error_count'];
+            // var k8s_namespace = result_json_array.records[0]['k8s.namespace.name'];
             // console.log("production_error_count");
             // console.log(production_error_count);
             // console.log("k8s_namespace");
@@ -154,13 +162,13 @@ workflow:
             // -------------------------------------------- 
             var i = 0;
 
-            while (i < result_json_array.result.records.length) {
-              var k8s_namespace = result_json_array.result.records[i]['k8s.namespace.name'];
+            while (i < result_json_array.records.length) {
+              var k8s_namespace = result_json_array.records[i]['k8s.namespace.name'];
               console.log("k8s_namespace: " + k8s_namespace);
 
               if (k8s_namespace === "production"){
                 console.log("production k8s namespace found!");
-                production_error_count = result_json_array.result.records[i]['error_count'];
+                production_error_count = result_json_array.records[i]['error_count'];
               }
               
               i++;


### PR DESCRIPTION
DT Workflow template / sample that shows how to achieve the following:

1) Parse the result of a DQL query in JavaScript (iterate through result JSON array).
For quick testing: DQL query (first task) generates dummy data with DQL ‘data’ command

2) Based on the the processed result from 1), then trigger conditional branches (Jinja expressions). For example: 
- If production error count > 100 ---> branch Workflow into task A
- If production error count >= 0 and <= 100 ---> branch Workflow into task B
- If production namespace not found ---> branch Workflow into task C

![Workflow_Sample_JavaScript_Parse_DQL](https://github.com/Dynatrace/Dynatrace-workflow-samples/assets/14933193/a2580465-350e-44d1-91c4-51efd5413e78)
