### PR TITLE
Bugfix: Removes limit for only 1 finding in jira and slack notification critical vulnerability finding workflows

### DIFF
--- a/samples/security/vulnerability findings/jira_tickets_for_critical_vulnerabilities.yaml
+++ b/samples/security/vulnerability findings/jira_tickets_for_critical_vulnerabilities.yaml
@@ -56,8 +56,6 @@ workflow:
           24h)
 
           | sort vulnerability_finding_events[][scan_time] desc
-
-          | limit 1
       customSampleResult: {}
       position:
         x: 0

--- a/samples/security/vulnerability findings/slack_notifications_for_critical_vulnerabilities.yaml
+++ b/samples/security/vulnerability findings/slack_notifications_for_critical_vulnerabilities.yaml
@@ -206,8 +206,6 @@ workflow:
           24h)
 
           | sort vulnerability_finding_events[][scan_time] desc
-
-          | limit 1
       customSampleResult: {}
       position:
         x: 0


### PR DESCRIPTION
This PR removes the limit for only 1 finding result for both the jira and slack notification workflows for critical vulnerability findings.