### PR TITLE
Update security notification workflow samples for new semantic dictionary schema

### DIFF
--- a/samples/security/vulnerability findings/jira_tickets_for_critical_container_vulnerabilities.yaml
+++ b/samples/security/vulnerability findings/jira_tickets_for_critical_container_vulnerabilities.yaml
@@ -21,48 +21,73 @@ workflow:
       active: true
       input:
         query: >-
+          // The query has a rolling window of 7 days and the last 24hrs.
+
+          // Vulnerability finding events which have already been reported
+
+          // before the current 24hr window will not be reported again.
+
           fetch events, from: now() - 7d
 
           | filter dt.system.bucket == "default_security_custom_events"
+              AND event.kind == "SECURITY_EVENT"
+              AND object.type == "CONTAINER_IMAGE"
+              AND event.type == "VULNERABILITY_FINDING"
+              AND dt.security.risk.level == "CRITICAL"
+          // Aggregate vulnerability findings per vulnerability, repository, 
 
-          | filter event.kind == "SECURITY_EVENT"
-
-          | filter event.category == "VULNERABILITY_MANAGEMENT"
-
-          | filter affected_entity.type == "CONTAINER_IMAGE"
-
-          | filter event.type == "VULNERABILITY_FINDING_EVENT"
-
-          | filter vulnerability.risk.level == "CRITICAL"
-
-          | fieldsAdd repository_full_path = concat(event.provider_product, ":",
-          container_image.registry, ":", container_image.repository)
+          // component and component version.
 
           | summarize {
                 affected_images_count = count(),
                 vulnerability_finding_events = collectArray(
                   record(
-                    repository_full_path = repository_full_path,
-                    affected_entity.id = affected_entity.id,
-                    event.provider_product = event.provider_product,
+                    object.id = object.id,
+                    event.provider = event.provider,
+                    container_image.digest,
                     container_image.registry = container_image.registry,
                     container_image.repository = container_image.repository,
-                    vulnerable_component.version = vulnerable_component.version,
-                    vulnerable_component.short_name = vulnerable_component.short_name,
-                    vulnerability.risk.level = vulnerability.risk.level,
-                    vulnerability.title = vulnerability.title,
-                    vulnerability.external_id = vulnerability.external_id,
-                    vulnerability.description = vulnerability.description,
-                    container_image.tag = container_image.tag,
-                    container_image.digest = container_image.digest,
-                    scan_time = timestamp
+                    container_image.tags = container_image.tags,
+                    component.version = component.version,
+                    component.name = component.name,
+                    dt.security.risk.level = dt.security.risk.level,
+                    ingest_time = timestamp
                   )
                 )
-              }, by:{ vulnerability.external_id, repository_full_path}
-          | filterOut iAny(vulnerability_finding_events[][scan_time] < now() -
+              }, by:{ vulnerability.id, vulnerability.title, event.provider, container_image.registry, container_image.repository, component.name, component.version }
+          // Filter out, if this vulnerability for the repository and the
+          component 
+
+          // and version was already reported before the last 24 hours.
+
+          // For example, if the same vulnerability was reported multiple times
+
+          // during the last 7 days, don't report it again.
+
+          | filterOut iAny(vulnerability_finding_events[][ingest_time] < now() -
           24h)
 
-          | sort vulnerability_finding_events[][scan_time] desc
+          // Expand and deduplicate for repetitive findings if they
+
+          // were reported more than once in the last 24 hours.
+
+          | expand vulnerability_finding_events
+
+          | dedup { vulnerability.id, vulnerability.title,
+          vulnerability_finding_events[object.id],
+          vulnerability_finding_events[component.name],
+          vulnerability_finding_events[component.version] } 
+
+          // Aggregate again to count the unique affected images within each
+          repository.
+
+          | summarize {
+                affected_images_count = count(),
+                vulnerability_finding_events = collectArray(
+                  vulnerability_finding_events
+                )
+              }, by:{ vulnerability.id, vulnerability.title, event.provider, container_image.registry, container_image.repository, component.name, component.version }
+          | sort vulnerability_finding_events[][ingest_time] desc
       customSampleResult: {}
       position:
         x: 0
@@ -82,13 +107,13 @@ workflow:
         project:
           id: null
         summary: '{{
-          (_.finding.vulnerability_finding_events|first).get("vulnerability.risk.level")
-          }} vulnerability {{ _.finding.get("vulnerability.external_id") }} was
-          detected in {{
+          (_.finding.vulnerability_finding_events|first).get("dt.security.risk.level")
+          }} vulnerability {{ _.finding.get("vulnerability.id") }} was detected
+          in {{
           (_.finding.vulnerability_finding_events|first).get("container_image.repository")
           }}'
         assignee:
-          id: null
+          id: "-1"
         priority: null
         reporter:
           id: null
@@ -97,7 +122,7 @@ workflow:
         components: []
         description: >-
           *Finding source:* {{
-          (_.finding.vulnerability_finding_events|first).get("event.provider_product")
+          (_.finding.vulnerability_finding_events|first).get("event.provider")
           }}
 
           *Registry ID:* {{
@@ -111,33 +136,29 @@ workflow:
           *Number of affected images:* {{_.finding.affected_images_count}}
 
           *Vulnerable component (version):* {{
-          (_.finding.vulnerability_finding_events|first).get("vulnerable_component.short_name")
+          (_.finding.vulnerability_finding_events|first).get("component.name")
           }} ({{
-          (_.finding.vulnerability_finding_events|first).get("vulnerable_component.version")
+          (_.finding.vulnerability_finding_events|first).get("component.version")
           }})
 
 
           *Vulnerability severity:* {{
-          (_.finding.vulnerability_finding_events|first).get("vulnerability.risk.level")
+          (_.finding.vulnerability_finding_events|first).get("dt.security.risk.level")
           }}
 
-          *Vulnerability title:* {{
-          (_.finding.vulnerability_finding_events|first).get("vulnerability.title")
-          }}
+          *Vulnerability title:* {{ _.finding.get("vulnerability.title") }}
 
-          *Vulnerability ID:* {{
-          (_.finding.vulnerability_finding_events|first).get("vulnerability.external_id")
-          }}
+          *Vulnerability ID:* {{ _.finding.get("vulnerability.id") }}
 
 
-          [View all vulnerability findings in a
-          notebook.|{{result("get_environment_url")}}/ui/intent/dynatrace.notebooks/view-query#%7B%22dt.query%22%3A%22fetch%20events%5Cn%2F%2F%20data%20access%5Cn%7C%20filter%20dt.system.bucket%20%3D%3D%20%5C%22default_security_custom_events%5C%22%5Cn%20%20%20%20%20AND%20event.type%20%3D%3D%20%5C%22VULNERABILITY_FINDING_EVENT%5C%22%5Cn%20%20%20%20%20AND%20affected_entity.type%3D%3D%5C%22CONTAINER_IMAGE%5C%22%5Cn%20%20%20%20%20AND%20isNotNull(vulnerable_component.name)%5Cn%7C%20dedup%20%7Baffected_entity.id%2C%20vulnerability.external_id%2C%20vulnerable_component.name%2C%5Cn%20%20%20%20%20%20%20%20%20container_image.registry%2C%20container_image.repository%2C%20container_image.tags%7D%2C%20sort%3A%20%7Btimestamp%20desc%7D%5Cn%2F%2F%20aggregation%20and%20custom%20filtering%5Cn%7C%20sort%20timestamp%20desc%22%2C%22dt.timeframe%22%3A%7B%22from%22%3A%22now()-7d%22%2C%22to%22%3A%22now()%22%7D%2C%22hideInput%22%3Afalse%2C%22sourceApplication%22%3A%22dynatrace.notebooks%22%2C%22title%22%3A%22List%20recent%20container%20vulnerability%20findings%22%2C%22visualization%22%3A%22recordView%22%2C%22visualizationSettings%22%3A%7B%22thresholds%22%3A%5B%5D%2C%22chartSettings%22%3A%7B%22gapPolicy%22%3A%22connect%22%2C%22circleChartSettings%22%3A%7B%22groupingThresholdType%22%3A%22relative%22%2C%22groupingThresholdValue%22%3A0%2C%22valueType%22%3A%22relative%22%7D%2C%22categoryOverrides%22%3A%7B%7D%2C%22categoricalBarChartSettings%22%3A%7B%22categoryAxis%22%3A%22affected_entity.name%22%2C%22categoryAxisLabel%22%3A%22affected_entity.name%22%2C%22valueAxis%22%3A%22vulnerability.risk.score%22%2C%22valueAxisLabel%22%3A%22vulnerability.risk.score%22%7D%2C%22hiddenLegendFields%22%3A%5B%5D%2C%22fieldMapping%22%3A%7B%22timestamp%22%3A%22timestamp%22%2C%22leftAxisValues%22%3A%5B%22vulnerability.risk.score%22%5D%2C%22leftAxisDimensions%22%3A%5B%22ResponseMetadata%22%5D%7D%7D%2C%22singleValue%22%3A%7B%22showLabel%22%3Atrue%2C%22label%22%3A%22%22%2C%22prefixIcon%22%3A%22%22%2C%22recordField%22%3A%22timestamp%22%2C%22autoscale%22%3Atrue%2C%22alignment%22%3A%22center%22%2C%22colorThresholdTarget%22%3A%22value%22%7D%2C%22table%22%3A%7B%22rowDensity%22%3A%22condensed%22%2C%22enableSparklines%22%3Afalse%2C%22hiddenColumns%22%3A%5B%5D%2C%22lineWrapIds%22%3A%5B%5D%2C%22firstVisibleRowIndex%22%3A0%2C%22columnWidths%22%3A%7B%7D%7D%2C%22honeycomb%22%3A%7B%22shape%22%3A%22hexagon%22%2C%22legend%22%3A%22auto%22%2C%22dataMappings%22%3A%7B%22category%22%3A%22ResponseMetadata%22%2C%22value%22%3A%22timestamp%22%7D%7D%2C%22histogram%22%3A%7B%22dataMappings%22%3A%5B%7B%22valueAxis%22%3A%22vulnerability.risk.score%22%2C%22rangeAxis%22%3A%22%22%7D%5D%7D%7D%7D]
+          [View all vulnerability findings in a notebook.|{{ environment().url
+          }}/ui/intent/dynatrace.notebooks/view-query#%7B%22dt.query%22%3A%22fetch%20events%5Cn%2F%2F%20data%20access%5Cn%7C%20filter%20dt.system.bucket%20%3D%3D%20%5C%22default_security_custom_events%5C%22%5Cn%20%20%20%20%20AND%20event.type%20%3D%3D%20%5C%22VULNERABILITY_FINDING%5C%22%5Cn%20%20%20%20%20AND%20object.type%3D%3D%5C%22CONTAINER_IMAGE%5C%22%5Cn%20%20%20%20%20AND%20isNotNull(component.name)%5Cn%7C%20dedup%20%7Bobject.id%2C%20vulnerability.id%2C%20component.name%2C%5Cn%20%20%20%20%20%20%20%20%20container_image.registry%2C%20container_image.repository%2C%20container_image.tags%7D%2C%20sort%3A%20%7Btimestamp%20desc%7D%5Cn%2F%2F%20aggregation%20and%20custom%20filtering%5Cn%7C%20sort%20timestamp%20desc%22%2C%22dt.timeframe%22%3A%7B%22from%22%3A%22now()-7d%22%2C%22to%22%3A%22now()%22%7D%2C%22hideInput%22%3Afalse%2C%22sourceApplication%22%3A%22dynatrace.notebooks%22%2C%22title%22%3A%22List%20recent%20container%20vulnerability%20findings%22%2C%22visualization%22%3A%22recordView%22%2C%22visualizationSettings%22%3A%7B%22thresholds%22%3A%5B%5D%2C%22chartSettings%22%3A%7B%22gapPolicy%22%3A%22connect%22%2C%22circleChartSettings%22%3A%7B%22groupingThresholdType%22%3A%22relative%22%2C%22groupingThresholdValue%22%3A0%2C%22valueType%22%3A%22relative%22%7D%2C%22categoryOverrides%22%3A%7B%7D%2C%22categoricalBarChartSettings%22%3A%7B%22categoryAxis%22%3A%22object.id%22%2C%22categoryAxisLabel%22%3A%22object.id%22%2C%22valueAxis%22%3A%22dt.security.risk.score%22%2C%22valueAxisLabel%22%3A%22dt.security.risk.score%22%7D%2C%22hiddenLegendFields%22%3A%5B%5D%2C%22fieldMapping%22%3A%7B%22timestamp%22%3A%22timestamp%22%2C%22leftAxisValues%22%3A%5B%22dt.security.risk.score%22%5D%2C%22leftAxisDimensions%22%3A%5B%22ResponseMetadata%22%5D%7D%7D%2C%22singleValue%22%3A%7B%22showLabel%22%3Atrue%2C%22label%22%3A%22%22%2C%22prefixIcon%22%3A%22%22%2C%22recordField%22%3A%22timestamp%22%2C%22autoscale%22%3Atrue%2C%22alignment%22%3A%22center%22%2C%22colorThresholdTarget%22%3A%22value%22%7D%2C%22table%22%3A%7B%22rowDensity%22%3A%22condensed%22%2C%22enableSparklines%22%3Afalse%2C%22hiddenColumns%22%3A%5B%5D%2C%22lineWrapIds%22%3A%5B%5D%2C%22firstVisibleRowIndex%22%3A0%2C%22columnWidths%22%3A%7B%7D%7D%2C%22honeycomb%22%3A%7B%22shape%22%3A%22hexagon%22%2C%22legend%22%3A%22auto%22%2C%22dataMappings%22%3A%7B%22category%22%3A%22ResponseMetadata%22%2C%22value%22%3A%22timestamp%22%7D%7D%2C%22histogram%22%3A%7B%22dataMappings%22%3A%5B%7B%22valueAxis%22%3A%22dt.security.risk.score%22%2C%22rangeAxis%22%3A%22%22%7D%5D%7D%7D%7D]
 
 
-          ||Image Tag||Image digest (SHA256)||Scan time||
+          ||Image Tags||Image digest (SHA256)||Scan time||
 
           {% for entity in _.finding.vulnerability_finding_events %}
-            |{{ entity.get("container_image.tag") }}|{{ entity.get("container_image.digest") }}|{{ entity.get("scan_time") }}|
+            |{{ entity.get("container_image.tags") }}|{{ entity.get("container_image.digest") }}|{{ entity.get("ingest_time") }}|
           {% endfor %}
         executionId: "{{ execution().id }}"
         connectionId: ""
@@ -148,30 +169,12 @@ workflow:
         y: 2
       predecessors:
         - get_vulnerabilites
-        - get_environment_url
       conditions:
         states:
           get_vulnerabilites: SUCCESS
-          get_environment_url: SUCCESS
         custom: '{{result("get_vulnerabilites").records|length > 0}}'
       concurrency: 1
       withItems: finding in {{ result("get_vulnerabilites").records }}
-    get_environment_url:
-      name: get_environment_url
-      description: Fetch the environment URL.
-      action: dynatrace.automations:run-javascript
-      input:
-        script: |-
-          // optional import of sdk modules
-          import { getEnvironmentUrl } from '@dynatrace-sdk/app-environment';
-
-          export default async function () {
-            return getEnvironmentUrl();
-          }
-      position:
-        x: 1
-        y: 1
-      predecessors: []
   description: ""
   trigger:
     schedule:

--- a/samples/security/vulnerability findings/jira_tickets_for_critical_vulnerabilities.yaml
+++ b/samples/security/vulnerability findings/jira_tickets_for_critical_vulnerabilities.yaml
@@ -103,7 +103,7 @@ workflow:
         labels: []
         taskId: "{{ task().id }}"
         project:
-          id: "19691"
+          id: null
         summary: '{{
           (_.finding.vulnerability_finding_events|first).get("dt.security.risk.level")
           }} vulnerability {{ _.finding.get("vulnerability.id") }} was detected
@@ -114,7 +114,7 @@ workflow:
         priority: null
         reporter: null
         issueType:
-          id: "38"
+          id: null
         components: []
         description: >-
           *Finding source:* {{

--- a/samples/security/vulnerability findings/jira_tickets_for_critical_vulnerabilities.yaml
+++ b/samples/security/vulnerability findings/jira_tickets_for_critical_vulnerabilities.yaml
@@ -21,41 +21,71 @@ workflow:
       active: true
       input:
         query: >-
+          // The query has a rolling window of 7 days and the last 24hrs.
+
+          // Vulnerability finding events which have already been reported
+
+          // before the current 24hr window will not be reported again.
+
           fetch events, from: now() - 7d
 
-          // data access
-
           | filter dt.system.bucket == "default_security_custom_events"
-               AND event.type == "VULNERABILITY_FINDING_EVENT"
-               AND isNotNull(vulnerable_component.name)
-          | dedup {affected_entity.id, vulnerability.external_id,
-          vulnerable_component.name}, sort: {timestamp asc}
+               AND event.kind == "SECURITY_EVENT"
+               AND event.type == "VULNERABILITY_FINDING"
+               AND isNotNull(component.name)
+               AND dt.security.risk.level == "CRITICAL"
+          // Aggregate vulnerability findings per object.id, vulnerability, 
 
-          // aggregation and custom filtering
-
-          | filter vulnerability.risk.level=="CRITICAL"
+          // component and component version.
 
           | summarize {
                 vulnerable_components_count = count(),
                 vulnerability_finding_events = collectArray(
                   record(
-                    affected_entity.id = affected_entity.id,
-                    affected_entity.name = affected_entity.name,
-                    event.provider_product = event.provider_product,
-                    vulnerable_component.version = vulnerable_component.version,
-                    vulnerable_component.short_name = vulnerable_component.short_name,
-                    vulnerability.risk.level = vulnerability.risk.level,
+                    object.id = object.id,
+                    event.provider = event.provider,
+                    component.version = component.version,
+                    component.name = component.name,
+                    dt.security.risk.level = dt.security.risk.level,
                     vulnerability.title = vulnerability.title,
-                    vulnerability.external_id = vulnerability.external_id,
-                    vulnerability.description = vulnerability.description,
-                    scan_time = timestamp
+                    vulnerability.id = vulnerability.id,
+                    ingest_time = timestamp
                   )
                 )
-              }, by:{ vulnerability.external_id}
-          | filterOut iAny(vulnerability_finding_events[][scan_time] < now() -
+              }, by:{ object.id, vulnerability.id, component.name, component.version }
+          // Filter out, if this vulnerability for the object and the component 
+
+          // and version was already reported before the last 24 hours.
+
+          // For example, if the same vulnerability was reported multiple times
+
+          // during the last 7 days, don't report it again.
+
+          | filterOut iAny(vulnerability_finding_events[][ingest_time] < now() -
+
           24h)
 
-          | sort vulnerability_finding_events[][scan_time] desc
+          // Expand and deduplicate for repetitive findings if they
+
+          // were reported more than once in the last 24 hours.
+
+          | expand vulnerability_finding_events
+
+          | dedup { vulnerability_finding_events[object.id],
+          vulnerability_finding_events[vulnerability.id],
+          vulnerability_finding_events[component.name],
+          vulnerability_finding_events[component.version] } 
+
+          // Aggregate again to count the unique vulnerable components for each
+          vulnerability.
+
+          | summarize {
+                vulnerable_components_count = count(),
+                vulnerability_finding_events = collectArray(
+                  vulnerability_finding_events
+                )
+              }, by:{ vulnerability.id }
+          | sort vulnerability_finding_events[][ingest_time] desc
       customSampleResult: {}
       position:
         x: 0
@@ -73,14 +103,11 @@ workflow:
         labels: []
         taskId: "{{ task().id }}"
         project:
-          id: null
+          id: "19691"
         summary: '{{
-          (_.finding.vulnerability_finding_events|first).get("vulnerability.risk.level")
-          }} vulnerability {{ _.finding.get("vulnerability.external_id") }} was
-          detected in {{
-          (_.finding.vulnerability_finding_events|first).get("affected_entity.name")
-          or
-          (_.finding.vulnerability_finding_events|first).get("affected_entity.id")
+          (_.finding.vulnerability_finding_events|first).get("dt.security.risk.level")
+          }} vulnerability {{ _.finding.get("vulnerability.id") }} was detected
+          in {{ (_.finding.vulnerability_finding_events|first).get("object.id")
           or "unknown"}}'
         assignee:
           id: "-1"
@@ -91,23 +118,18 @@ workflow:
         components: []
         description: >-
           *Finding source:* {{
-          (_.finding.vulnerability_finding_events|first).get("event.provider_product")
+          (_.finding.vulnerability_finding_events|first).get("event.provider")
           }}
 
-          *Affected entity name:* {{
-          (_.finding.vulnerability_finding_events|first).get("affected_entity.name")
-          }}
-
-          *Affected entity ID:* {{
-          (_.finding.vulnerability_finding_events|first).get("affected_entity.id")
-          }}
+          *Affected object ID:* {{
+          (_.finding.vulnerability_finding_events|first).get("object.id") }}
 
           *Number of vulnerable components:* {{
           (_.finding.vulnerable_components_count)}}
 
 
           *Vulnerability severity:* {{
-          (_.finding.vulnerability_finding_events|first).get("vulnerability.risk.level")
+          (_.finding.vulnerability_finding_events|first).get("dt.security.risk.level")
           }}
 
           *Vulnerability title:* {{
@@ -115,21 +137,20 @@ workflow:
           }}
 
           *Vulnerability ID:* {{
-          (_.finding.vulnerability_finding_events|first).get("vulnerability.external_id")
+          (_.finding.vulnerability_finding_events|first).get("vulnerability.id")
           }}
 
 
-          [View all vulnerability findings in a notebook.|{{
-          environment().url}}/ui/intent/dynatrace.notebooks/view-query#%7B%22dt.query%22%3A%22fetch%20events%5Cn%2F%2F%20data%20access%5Cn%7C%20filter%20dt.system.bucket%20%3D%3D%20%5C%22default_security_custom_events%5C%22%5Cn%20%20%20%20%20AND%20event.type%20%3D%3D%20%5C%22VULNERABILITY_FINDING_EVENT%5C%22%5Cn%20%20%20%20%20AND%20isNotNull(vulnerable_component.name)%5Cn%7C%20dedup%20%7Baffected_entity.id%2C%20vulnerability.external_id%2C%20vulnerable_component.name%7D%2C%20sort%3A%20%7Btimestamp%20desc%7D%5Cn%2F%2F%20aggregation%20and%20custom%20filtering%5Cn%7C%20sort%20timestamp%20desc%22%2C%22dt.timeframe%22%3A%7B%22from%22%3A%22now()-7d%22%2C%22to%22%3A%22now()%22%7D%2C%22hideInput%22%3Afalse%2C%22sourceApplication%22%3A%22dynatrace.notebooks%22%2C%22title%22%3A%22List%20recent%20vulnerability%20findings%22%2C%22visualization%22%3A%22recordView%22%2C%22visualizationSettings%22%3A%7B%22thresholds%22%3A%5B%5D%2C%22chartSettings%22%3A%7B%22gapPolicy%22%3A%22connect%22%2C%22circleChartSettings%22%3A%7B%22groupingThresholdType%22%3A%22relative%22%2C%22groupingThresholdValue%22%3A0%2C%22valueType%22%3A%22relative%22%7D%2C%22categoryOverrides%22%3A%7B%7D%2C%22curve%22%3A%22linear%22%2C%22pointsDisplay%22%3A%22auto%22%2C%22categoricalBarChartSettings%22%3A%7B%22categoryAxis%22%3A%22affected_entity.name%22%2C%22categoryAxisLabel%22%3A%22affected_entity.name%22%2C%22valueAxis%22%3A%22vulnerability.risk.score%22%2C%22valueAxisLabel%22%3A%22vulnerability.risk.score%22%2C%22tooltipVariant%22%3A%22single%22%7D%2C%22hiddenLegendFields%22%3A%5B%5D%2C%22fieldMapping%22%3A%7B%22timestamp%22%3A%22timestamp%22%2C%22leftAxisValues%22%3A%5B%22vulnerability.risk.score%22%5D%2C%22leftAxisDimensions%22%3A%5B%22account%22%5D%7D%7D%2C%22singleValue%22%3A%7B%22showLabel%22%3Atrue%2C%22label%22%3A%22%22%2C%22prefixIcon%22%3A%22%22%2C%22recordField%22%3A%22timestamp%22%2C%22autoscale%22%3Atrue%2C%22alignment%22%3A%22center%22%2C%22colorThresholdTarget%22%3A%22value%22%7D%2C%22table%22%3A%7B%22rowDensity%22%3A%22condensed%22%2C%22enableSparklines%22%3Afalse%2C%22hiddenColumns%22%3A%5B%5D%2C%22lineWrapIds%22%3A%5B%5D%2C%22firstVisibleRowIndex%22%3A0%2C%22columnWidths%22%3A%7B%7D%2C%22enableThresholdInRow%22%3Afalse%7D%2C%22honeycomb%22%3A%7B%22shape%22%3A%22hexagon%22%2C%22legend%22%3A%22auto%22%2C%22colorMode%22%3A%22color-palette%22%2C%22colorPalette%22%3A%22blue%22%2C%22dataMappings%22%3A%7B%22value%22%3A%22vulnerability.risk.score%22%7D%2C%22displayedFields%22%3A%5B%22account%22%5D%7D%2C%22histogram%22%3A%7B%22dataMappings%22%3A%5B%7B%22valueAxis%22%3A%22vulnerability.risk.score%22%2C%22rangeAxis%22%3A%22%22%7D%2C%7B%22valueAxis%22%3A%22activity_id%22%2C%22rangeAxis%22%3A%22%22%7D%2C%7B%22valueAxis%22%3A%22category_uid%22%2C%22rangeAxis%22%3A%22%22%7D%2C%7B%22valueAxis%22%3A%22class_uid%22%2C%22rangeAxis%22%3A%22%22%7D%2C%7B%22valueAxis%22%3A%22severity_id%22%2C%22rangeAxis%22%3A%22%22%7D%2C%7B%22valueAxis%22%3A%22time%22%2C%22rangeAxis%22%3A%22%22%7D%2C%7B%22valueAxis%22%3A%22type_uid%22%2C%22rangeAxis%22%3A%22%22%7D%5D%7D%7D%7D]
-
+          [View all vulnerability findings in a notebook.|{{ environment().url
+          }}/ui/intent/dynatrace.notebooks/view-query#%7B%22title%22%3A%22List%20recent%20vulnerability%20findings%22%2C%22visualization%22%3A%22recordView%22%2C%22visualizationSettings%22%3A%7B%22thresholds%22%3A%5B%5D%2C%22chartSettings%22%3A%7B%22gapPolicy%22%3A%22connect%22%2C%22circleChartSettings%22%3A%7B%22groupingThresholdType%22%3A%22relative%22%2C%22groupingThresholdValue%22%3A0%2C%22valueType%22%3A%22relative%22%7D%2C%22categoryOverrides%22%3A%7B%7D%2C%22curve%22%3A%22linear%22%2C%22pointsDisplay%22%3A%22auto%22%2C%22categoricalBarChartSettings%22%3A%7B%22layout%22%3A%22horizontal%22%2C%22categoryAxisTickLayout%22%3A%22horizontal%22%2C%22scale%22%3A%22absolute%22%2C%22groupMode%22%3A%22stacked%22%2C%22colorPaletteMode%22%3A%22multi-color%22%2C%22categoryAxis%22%3A%5B%22account%22%2C%22aws.account.id%22%2C%22aws.region%22%2C%22aws.resource.id%22%2C%22component.name%22%2C%22component.version%22%2C%22container_image.digest%22%2C%22container_image.registry%22%2C%22container_image.repository%22%2C%22detail%22%2C%22detail-type%22%2C%22dt.openpipeline.source%22%2C%22dt.security.risk.level%22%2C%22event.category%22%2C%22event.description%22%2C%22event.id%22%2C%22event.kind%22%2C%22event.name%22%2C%22event.provider%22%2C%22event.type%22%2C%22event.version%22%2C%22finding.description%22%2C%22finding.id%22%2C%22finding.title%22%2C%22id%22%2C%22object.id%22%2C%22object.type%22%2C%22region%22%2C%22source%22%2C%22time%22%2C%22uuid%22%2C%22version%22%2C%22vulnerability.description%22%2C%22vulnerability.id%22%2C%22vulnerability.title%22%2C%22activity_name%22%2C%22category_name%22%2C%22class_name%22%2C%22cloud%22%2C%22finding_info%22%2C%22metadata%22%2C%22resource%22%2C%22severity%22%2C%22status%22%2C%22time_dt%22%2C%22type_name%22%2C%22unmapped%22%2C%22ResponseMetadata%22%2C%22imageId%22%2C%22imageScanFindings%22%2C%22imageScanStatus%22%2C%22provider_product%22%2C%22registryId%22%2C%22repositoryName%22%2C%22type%22%5D%2C%22categoryAxisLabel%22%3A%22account%2Caws.account.id%2Caws.region%2Caws.resource.id%2Ccomponent.name%2Ccomponent.version%2Ccontainer_image.digest%2Ccontainer_image.registry%2Ccontainer_image.repository%2Cdetail%2Cdetail-type%2Cdt.openpipeline.source%2Cdt.security.risk.level%2Cevent.category%2Cevent.description%2Cevent.id%2Cevent.kind%2Cevent.name%2Cevent.provider%2Cevent.type%2Cevent.version%2Cfinding.description%2Cfinding.id%2Cfinding.title%2Cid%2Cobject.id%2Cobject.type%2Cregion%2Csource%2Ctime%2Cuuid%2Cversion%2Cvulnerability.description%2Cvulnerability.id%2Cvulnerability.title%2Cactivity_name%2Ccategory_name%2Cclass_name%2Ccloud%2Cfinding_info%2Cmetadata%2Cresource%2Cseverity%2Cstatus%2Ctime_dt%2Ctype_name%2Cunmapped%2CResponseMetadata%2CimageId%2CimageScanFindings%2CimageScanStatus%2Cprovider_product%2CregistryId%2CrepositoryName%2Ctype%22%2C%22valueAxis%22%3A%5B%22dt.security.risk.score%22%2C%22activity_id%22%2C%22category_uid%22%2C%22class_uid%22%2C%22severity_id%22%2C%22time%22%2C%22type_uid%22%5D%2C%22valueAxisLabel%22%3A%22dt.security.risk.score%2Cactivity_id%2Ccategory_uid%2Cclass_uid%2Cseverity_id%2Ctime%2Ctype_uid%22%2C%22tooltipVariant%22%3A%22single%22%7D%2C%22colorPalette%22%3A%22categorical%22%2C%22valueRepresentation%22%3A%22absolute%22%2C%22xAxisScaling%22%3A%22analyzedTimeframe%22%2C%22hiddenLegendFields%22%3A%5B%5D%2C%22fieldMapping%22%3A%7B%22timestamp%22%3A%22timestamp%22%2C%22leftAxisValues%22%3A%5B%22dt.security.risk.score%22%5D%2C%22leftAxisDimensions%22%3A%5B%22account%22%5D%7D%2C%22truncationMode%22%3A%22middle%22%7D%2C%22singleValue%22%3A%7B%22showLabel%22%3Atrue%2C%22label%22%3A%22%22%2C%22prefixIcon%22%3A%22%22%2C%22recordField%22%3A%22timestamp%22%2C%22autoscale%22%3Atrue%2C%22alignment%22%3A%22center%22%2C%22trend%22%3A%7B%22trendType%22%3A%22auto%22%2C%22isVisible%22%3Afalse%7D%2C%22colorThresholdTarget%22%3A%22value%22%7D%2C%22table%22%3A%7B%22rowDensity%22%3A%22condensed%22%2C%22enableSparklines%22%3Afalse%2C%22hiddenColumns%22%3A%5B%5D%2C%22linewrapEnabled%22%3Afalse%2C%22lineWrapIds%22%3A%5B%5D%2C%22monospacedFontEnabled%22%3Afalse%2C%22monospacedFontColumns%22%3A%5B%5D%2C%22firstVisibleRowIndex%22%3A0%2C%22columnWidths%22%3A%7B%7D%2C%22columnTypeOverrides%22%3A%5B%5D%2C%22enableThresholdInRow%22%3Afalse%7D%2C%22honeycomb%22%3A%7B%22shape%22%3A%22hexagon%22%2C%22legend%22%3A%22auto%22%2C%22displayedFields%22%3A%5B%22account%22%2C%22aws.account.id%22%2C%22aws.region%22%2C%22aws.resource.id%22%2C%22component.name%22%2C%22component.version%22%2C%22container_image.digest%22%2C%22container_image.registry%22%2C%22container_image.repository%22%2C%22detail%22%2C%22detail-type%22%2C%22dt.openpipeline.source%22%2C%22dt.security.risk.level%22%2C%22event.category%22%2C%22event.description%22%2C%22event.id%22%2C%22event.kind%22%2C%22event.name%22%2C%22event.provider%22%2C%22event.type%22%2C%22event.version%22%2C%22finding.description%22%2C%22finding.id%22%2C%22finding.title%22%2C%22id%22%2C%22object.id%22%2C%22object.type%22%2C%22region%22%2C%22source%22%2C%22time%22%2C%22uuid%22%2C%22version%22%2C%22vulnerability.description%22%2C%22vulnerability.id%22%2C%22vulnerability.title%22%2C%22activity_name%22%2C%22category_name%22%2C%22class_name%22%2C%22cloud%22%2C%22finding_info%22%2C%22metadata%22%2C%22resource%22%2C%22severity%22%2C%22status%22%2C%22time_dt%22%2C%22type_name%22%2C%22unmapped%22%2C%22ResponseMetadata%22%2C%22imageId%22%2C%22imageScanFindings%22%2C%22imageScanStatus%22%2C%22provider_product%22%2C%22registryId%22%2C%22repositoryName%22%2C%22type%22%5D%2C%22dataMappings%22%3A%7B%22value%22%3A%22dt.security.risk.score%22%7D%2C%22colorMode%22%3A%22color-palette%22%2C%22colorPalette%22%3A%22blue%22%7D%2C%22histogram%22%3A%7B%22legend%22%3A%22auto%22%2C%22yAxis%22%3A%7B%22label%22%3A%22Frequency%22%2C%22scale%22%3A%22linear%22%7D%2C%22colorPalette%22%3A%22categorical%22%2C%22dataMappings%22%3A%5B%7B%22valueAxis%22%3A%22dt.security.risk.score%22%2C%22rangeAxis%22%3A%22%22%7D%2C%7B%22valueAxis%22%3A%22activity_id%22%2C%22rangeAxis%22%3A%22%22%7D%2C%7B%22valueAxis%22%3A%22category_uid%22%2C%22rangeAxis%22%3A%22%22%7D%2C%7B%22valueAxis%22%3A%22class_uid%22%2C%22rangeAxis%22%3A%22%22%7D%2C%7B%22valueAxis%22%3A%22severity_id%22%2C%22rangeAxis%22%3A%22%22%7D%2C%7B%22valueAxis%22%3A%22time%22%2C%22rangeAxis%22%3A%22%22%7D%2C%7B%22valueAxis%22%3A%22type_uid%22%2C%22rangeAxis%22%3A%22%22%7D%5D%2C%22variant%22%3A%22single%22%2C%22displayedFields%22%3A%5B%22account%22%2C%22container_image.digest%22%2C%22container_image.registry%22%2C%22container_image.repository%22%2C%22detail%22%2C%22detail-type%22%2C%22dt.openpipeline.source%22%2C%22event.category%22%2C%22event.description%22%2C%22event.kind%22%2C%22event.name%22%2C%22event.provider%22%2C%22event.type%22%2C%22id%22%2C%22region%22%2C%22source%22%2C%22time%22%2C%22uuid%22%2C%22version%22%2C%22vulnerability.description%22%2C%22vulnerability.title%22%2C%22activity_name%22%2C%22category_name%22%2C%22class_name%22%2C%22cloud%22%2C%22finding_info%22%2C%22metadata%22%2C%22resource%22%2C%22severity%22%2C%22status%22%2C%22time_dt%22%2C%22type_name%22%2C%22unmapped%22%2C%22ResponseMetadata%22%2C%22imageId%22%2C%22imageScanFindings%22%2C%22imageScanStatus%22%2C%22provider_product%22%2C%22registryId%22%2C%22repositoryName%22%2C%22type%22%5D%7D%7D%2C%22dt.timeframe%22%3A%7B%22from%22%3A%22now()-7d%22%2C%22to%22%3A%22now()%22%7D%2C%22dt.query%22%3A%22fetch%20events%5Cn%2F%2F%20data%20access%5Cn%7C%20filter%20dt.system.bucket%20%3D%3D%20%5C%22default_security_custom_events%5C%22%5Cn%20%20%20%20%20AND%20event.type%20%3D%3D%20%5C%22VULNERABILITY_FINDING%5C%22%5Cn%20%20%20%20%20AND%20isNotNull(component.name)%5Cn%7C%20dedup%20%7Bobject.id%2C%20vulnerability.id%2C%20component.name%7D%2C%20sort%3A%20%7Btimestamp%20desc%7D%5Cn%2F%2F%20aggregation%20and%20custom%20filtering%5Cn%7C%20sort%20timestamp%20desc%22%2C%22hideInput%22%3Afalse%2C%22sourceApplication%22%3A%22dynatrace.notebooks%22%7D]
 
 
           ||Component name||Component version||
 
           {% for component in _.finding.vulnerability_finding_events  %}
 
-          |{{ component.get("vulnerable_component.short_name") }}|{{
-          component.get("vulnerable_component.version") }}|
+          |{{ component.get("component.name") }}|{{
+          component.get("component.version") }}|
 
           {% endfor %}
         executionId: "{{ execution().id }}"

--- a/samples/security/vulnerability findings/slack_notifications_for_critical_container_vulnerabilities.yaml
+++ b/samples/security/vulnerability findings/slack_notifications_for_critical_container_vulnerabilities.yaml
@@ -28,7 +28,7 @@ workflow:
           			"type": "header",
           			"text": {
           				"type": "plain_text",
-          				"text": "{{ (_.finding.vulnerability_finding_events|first).get("vulnerability.risk.level") }} vulnerability was detected!",
+          				"text": "{{ (_.finding.vulnerability_finding_events|first).get("dt.security.risk.level") }} vulnerability was detected!",
           				"emoji": true
           			}
           		},
@@ -39,7 +39,7 @@ workflow:
           			"type": "section",
           			"text": {
           				"type": "mrkdwn",
-          				"text": "{{ (_.finding.vulnerability_finding_events|first).get("vulnerability.risk.level") }} vulnerability `{{ _.finding.get("vulnerability.external_id") }}` was detected in `{{ (_.finding.vulnerability_finding_events|first).get("container_image.repository") }}`"
+          				"text": "{{ (_.finding.vulnerability_finding_events|first).get("dt.security.risk.level") }} vulnerability `{{ _.finding.get("vulnerability.id") }}` was detected in `{{ (_.finding.vulnerability_finding_events|first).get("container_image.repository") }}`"
           			},
           			"accessory": {
           				"type": "image",
@@ -75,7 +75,7 @@ workflow:
           								},
           								{
           									"type": "text",
-          									"text": "{{ (_.finding.vulnerability_finding_events|first).get("event.provider_product") }}"
+          									"text": "{{ (_.finding.vulnerability_finding_events|first).get("event.provider") }}"
           								}
           							]
           						},
@@ -127,7 +127,7 @@ workflow:
           								},
           								{
           									"type": "text",
-          									"text": "{{ (_.finding.vulnerability_finding_events|first).get("vulnerable_component.short_name") }} ({{ (_.finding.vulnerability_finding_events|first).get("vulnerable_component.version") }})"
+          									"text": "{{ (_.finding.vulnerability_finding_events|first).get("component.name") }} ({{ (_.finding.vulnerability_finding_events|first).get("component.version") }})"
           								}
           							]
           						}
@@ -151,7 +151,7 @@ workflow:
           					"text": "View all findings",
           					"emoji": true
           				},
-          				"url": "{{result("get_environment_url")}}/ui/intent/dynatrace.notebooks/view-query#%7B%22dt.query%22%3A%22fetch%20events%5Cn%2F%2F%20data%20access%5Cn%7C%20filter%20dt.system.bucket%20%3D%3D%20%5C%22default_security_custom_events%5C%22%5Cn%20%20%20%20%20AND%20event.type%20%3D%3D%20%5C%22VULNERABILITY_FINDING_EVENT%5C%22%5Cn%20%20%20%20%20AND%20affected_entity.type%3D%3D%5C%22CONTAINER_IMAGE%5C%22%5Cn%20%20%20%20%20AND%20isNotNull(vulnerable_component.name)%5Cn%7C%20dedup%20%7Baffected_entity.id%2C%20vulnerability.external_id%2C%20vulnerable_component.name%2C%5Cn%20%20%20%20%20%20%20%20%20container_image.registry%2C%20container_image.repository%2C%20container_image.tags%7D%2C%20sort%3A%20%7Btimestamp%20desc%7D%5Cn%2F%2F%20aggregation%20and%20custom%20filtering%5Cn%7C%20sort%20timestamp%20desc%22%2C%22dt.timeframe%22%3A%7B%22from%22%3A%22now()-7d%22%2C%22to%22%3A%22now()%22%7D%2C%22hideInput%22%3Afalse%2C%22sourceApplication%22%3A%22dynatrace.notebooks%22%2C%22title%22%3A%22List%20recent%20container%20vulnerability%20findings%22%2C%22visualization%22%3A%22recordView%22%2C%22visualizationSettings%22%3A%7B%22thresholds%22%3A%5B%5D%2C%22chartSettings%22%3A%7B%22gapPolicy%22%3A%22connect%22%2C%22circleChartSettings%22%3A%7B%22groupingThresholdType%22%3A%22relative%22%2C%22groupingThresholdValue%22%3A0%2C%22valueType%22%3A%22relative%22%7D%2C%22categoryOverrides%22%3A%7B%7D%2C%22categoricalBarChartSettings%22%3A%7B%22categoryAxis%22%3A%22affected_entity.name%22%2C%22categoryAxisLabel%22%3A%22affected_entity.name%22%2C%22valueAxis%22%3A%22vulnerability.risk.score%22%2C%22valueAxisLabel%22%3A%22vulnerability.risk.score%22%7D%2C%22hiddenLegendFields%22%3A%5B%5D%2C%22fieldMapping%22%3A%7B%22timestamp%22%3A%22timestamp%22%2C%22leftAxisValues%22%3A%5B%22vulnerability.risk.score%22%5D%2C%22leftAxisDimensions%22%3A%5B%22ResponseMetadata%22%5D%7D%7D%2C%22singleValue%22%3A%7B%22showLabel%22%3Atrue%2C%22label%22%3A%22%22%2C%22prefixIcon%22%3A%22%22%2C%22recordField%22%3A%22timestamp%22%2C%22autoscale%22%3Atrue%2C%22alignment%22%3A%22center%22%2C%22colorThresholdTarget%22%3A%22value%22%7D%2C%22table%22%3A%7B%22rowDensity%22%3A%22condensed%22%2C%22enableSparklines%22%3Afalse%2C%22hiddenColumns%22%3A%5B%5D%2C%22lineWrapIds%22%3A%5B%5D%2C%22firstVisibleRowIndex%22%3A0%2C%22columnWidths%22%3A%7B%7D%7D%2C%22honeycomb%22%3A%7B%22shape%22%3A%22hexagon%22%2C%22legend%22%3A%22auto%22%2C%22dataMappings%22%3A%7B%22category%22%3A%22ResponseMetadata%22%2C%22value%22%3A%22timestamp%22%7D%7D%2C%22histogram%22%3A%7B%22dataMappings%22%3A%5B%7B%22valueAxis%22%3A%22vulnerability.risk.score%22%2C%22rangeAxis%22%3A%22%22%7D%5D%7D%7D%7D",
+          				"url": "{{ environment().url }}/ui/intent/dynatrace.notebooks/view-query#%7B%22dt.query%22%3A%22fetch%20events%5Cn%2F%2F%20data%20access%5Cn%7C%20filter%20dt.system.bucket%20%3D%3D%20%5C%22default_security_custom_events%5C%22%5Cn%20%20%20%20%20AND%20event.type%20%3D%3D%20%5C%22VULNERABILITY_FINDING%5C%22%5Cn%20%20%20%20%20AND%20object.type%3D%3D%5C%22CONTAINER_IMAGE%5C%22%5Cn%20%20%20%20%20AND%20isNotNull(component.name)%5Cn%7C%20dedup%20%7Bobject.id%2C%20vulnerability.id%2C%20component.name%2C%5Cn%20%20%20%20%20%20%20%20%20container_image.registry%2C%20container_image.repository%2C%20container_image.tags%7D%2C%20sort%3A%20%7Btimestamp%20desc%7D%5Cn%2F%2F%20aggregation%20and%20custom%20filtering%5Cn%7C%20sort%20timestamp%20desc%22%2C%22dt.timeframe%22%3A%7B%22from%22%3A%22now()-7d%22%2C%22to%22%3A%22now()%22%7D%2C%22hideInput%22%3Afalse%2C%22sourceApplication%22%3A%22dynatrace.notebooks%22%2C%22title%22%3A%22List%20recent%20container%20vulnerability%20findings%22%2C%22visualization%22%3A%22recordView%22%2C%22visualizationSettings%22%3A%7B%22thresholds%22%3A%5B%5D%2C%22chartSettings%22%3A%7B%22gapPolicy%22%3A%22connect%22%2C%22circleChartSettings%22%3A%7B%22groupingThresholdType%22%3A%22relative%22%2C%22groupingThresholdValue%22%3A0%2C%22valueType%22%3A%22relative%22%7D%2C%22categoryOverrides%22%3A%7B%7D%2C%22categoricalBarChartSettings%22%3A%7B%22categoryAxis%22%3A%22object.id%22%2C%22categoryAxisLabel%22%3A%22object.id%22%2C%22valueAxis%22%3A%22dt.security.risk.score%22%2C%22valueAxisLabel%22%3A%22dt.security.risk.score%22%7D%2C%22hiddenLegendFields%22%3A%5B%5D%2C%22fieldMapping%22%3A%7B%22timestamp%22%3A%22timestamp%22%2C%22leftAxisValues%22%3A%5B%22dt.security.risk.score%22%5D%2C%22leftAxisDimensions%22%3A%5B%22ResponseMetadata%22%5D%7D%7D%2C%22singleValue%22%3A%7B%22showLabel%22%3Atrue%2C%22label%22%3A%22%22%2C%22prefixIcon%22%3A%22%22%2C%22recordField%22%3A%22timestamp%22%2C%22autoscale%22%3Atrue%2C%22alignment%22%3A%22center%22%2C%22colorThresholdTarget%22%3A%22value%22%7D%2C%22table%22%3A%7B%22rowDensity%22%3A%22condensed%22%2C%22enableSparklines%22%3Afalse%2C%22hiddenColumns%22%3A%5B%5D%2C%22lineWrapIds%22%3A%5B%5D%2C%22firstVisibleRowIndex%22%3A0%2C%22columnWidths%22%3A%7B%7D%7D%2C%22honeycomb%22%3A%7B%22shape%22%3A%22hexagon%22%2C%22legend%22%3A%22auto%22%2C%22dataMappings%22%3A%7B%22category%22%3A%22ResponseMetadata%22%2C%22value%22%3A%22timestamp%22%7D%7D%2C%22histogram%22%3A%7B%22dataMappings%22%3A%5B%7B%22valueAxis%22%3A%22dt.security.risk.score%22%2C%22rangeAxis%22%3A%22%22%7D%5D%7D%7D%7D",
           				"action_id": "button-action"
           			}
           		}
@@ -171,11 +171,9 @@ workflow:
         y: 2
       predecessors:
         - get_vulnerabilites
-        - get_environment_url
       conditions:
         states:
           get_vulnerabilites: SUCCESS
-          get_environment_url: SUCCESS
         custom: '{{result("get_vulnerabilites").records|length > 0}}'
       concurrency: 1
       withItems: finding in {{ result("get_vulnerabilites").records }}
@@ -186,48 +184,71 @@ workflow:
       active: true
       input:
         query: >-
+          // The query has a rolling window of 7 days and the last 24hrs.
+
+          // Vulnerability finding events which have already been reported
+
+          // before the current 24hr window will not be reported again.
+
           fetch events, from: now() - 7d
 
           | filter dt.system.bucket == "default_security_custom_events"
+              AND event.kind == "SECURITY_EVENT"
+              AND object.type == "CONTAINER_IMAGE"
+              AND event.type == "VULNERABILITY_FINDING"
+              AND dt.security.risk.level == "CRITICAL"
+          // Aggregate vulnerability findings per vulnerability, repository, 
 
-          | filter event.kind == "SECURITY_EVENT"
-
-          | filter event.category == "VULNERABILITY_MANAGEMENT"
-
-          | filter affected_entity.type == "CONTAINER_IMAGE"
-
-          | filter event.type == "VULNERABILITY_FINDING_EVENT"
-
-          | filter vulnerability.risk.level == "CRITICAL"
-
-          | fieldsAdd repository_full_path = concat(event.provider_product, ":",
-          container_image.registry, ":", container_image.repository)
+          // component and component version.
 
           | summarize {
                 affected_images_count = count(),
                 vulnerability_finding_events = collectArray(
                   record(
-                    repository_full_path = repository_full_path,
-                    affected_entity.id = affected_entity.id,
-                    event.provider_product = event.provider_product,
+                    object.id = object.id,
+                    event.provider = event.provider,
                     container_image.registry = container_image.registry,
                     container_image.repository = container_image.repository,
-                    vulnerable_component.version = vulnerable_component.version,
-                    vulnerable_component.short_name = vulnerable_component.short_name,
-                    vulnerability.risk.level = vulnerability.risk.level,
-                    vulnerability.title = vulnerability.title,
-                    vulnerability.external_id = vulnerability.external_id,
-                    vulnerability.description = vulnerability.description,
-                    container_image.tag = container_image.tag,
-                    container_image.digest = container_image.digest,
-                    scan_time = timestamp
+                    component.version = component.version,
+                    component.name = component.name,
+                    dt.security.risk.level = dt.security.risk.level,
+                    ingest_time = timestamp
                   )
                 )
-              }, by:{ vulnerability.external_id, repository_full_path}
-          | filterOut iAny(vulnerability_finding_events[][scan_time] < now() -
+              }, by:{ vulnerability.id, vulnerability.title, event.provider, container_image.registry, container_image.repository, component.name, component.version }
+          // Filter out, if this vulnerability for the repository and the
+          component 
+
+          // and version was already reported before the last 24 hours.
+
+          // For example, if the same vulnerability was reported multiple times
+
+          // during the last 7 days, don't report it again.
+
+          | filterOut iAny(vulnerability_finding_events[][ingest_time] < now() -
           24h)
 
-          | sort vulnerability_finding_events[][scan_time] desc
+          // Expand and deduplicate for repetitive findings if they
+
+          // were reported more than once in the last 24 hours.
+
+          | expand vulnerability_finding_events
+
+          | dedup { vulnerability.id, vulnerability.title,
+          vulnerability_finding_events[object.id],
+          vulnerability_finding_events[component.name],
+          vulnerability_finding_events[component.version] } 
+
+          // Aggregate again to count the unique affected images within each
+          repository.
+
+          | summarize {
+                affected_images_count = count(),
+                vulnerability_finding_events = collectArray(
+                  vulnerability_finding_events
+                )
+              }, by:{ vulnerability.id, vulnerability.title, event.provider, container_image.registry, container_image.repository, component.name, component.version }
+          | sort vulnerability_finding_events[][ingest_time] desc
       customSampleResult: {}
       position:
         x: 0
@@ -236,22 +257,6 @@ workflow:
       conditions:
         states: {}
         custom: ""
-    get_environment_url:
-      name: get_environment_url
-      description: Fetch the environment URL.
-      action: dynatrace.automations:run-javascript
-      input:
-        script: |-
-          // optional import of sdk modules
-          import { getEnvironmentUrl } from '@dynatrace-sdk/app-environment';
-
-          export default async function () {
-            return getEnvironmentUrl();
-          }
-      position:
-        x: 1
-        y: 1
-      predecessors: []
   description: ""
   trigger:
     schedule:

--- a/samples/security/vulnerability findings/slack_notifications_for_critical_vulnerabilities.yaml
+++ b/samples/security/vulnerability findings/slack_notifications_for_critical_vulnerabilities.yaml
@@ -28,7 +28,7 @@ workflow:
           			"type": "header",
           			"text": {
           				"type": "plain_text",
-          				"text": "{{ (_.finding.vulnerability_finding_events|first).get("vulnerability.risk.level") }} vulnerability was detected!",
+          				"text": "{{ (_.finding.vulnerability_finding_events|first).get("dt.security.risk.level") }} vulnerability was detected!",
           				"emoji": true
           			}
           		},
@@ -39,7 +39,7 @@ workflow:
           			"type": "section",
           			"text": {
           				"type": "mrkdwn",
-          				"text": "{{ (_.finding.vulnerability_finding_events|first).get("vulnerability.risk.level") }} vulnerability `{{ _.finding.get("vulnerability.external_id") }}` was detected in `{{ (_.finding.vulnerability_finding_events|first).get("affected_entity.name") }}`"
+          				"text": "{{ (_.finding.vulnerability_finding_events|first).get("dt.security.risk.level") }} vulnerability `{{ _.finding.get("vulnerability.id") }}` was detected in `{{ (_.finding.vulnerability_finding_events|first).get("object.id") }}`"
           			},
           			"accessory": {
           				"type": "image",
@@ -75,7 +75,7 @@ workflow:
           								},
           								{
           									"type": "text",
-          									"text": "{{ (_.finding.vulnerability_finding_events|first).get("event.provider_product") }}"
+          									"text": "{{ (_.finding.vulnerability_finding_events|first).get("event.provider") }}"
           								}
           							]
           						},
@@ -84,24 +84,11 @@ workflow:
           							"elements": [
           								{
           									"type": "text",
-          									"text": "Affected entity name: "
+          									"text": "Affected object id: "
           								},
           								{
           									"type": "text",
-          									"text": "{{ (_.finding.vulnerability_finding_events|first).get("affected_entity.name") }}"
-          								}
-          							]
-          						},
-          						{
-          							"type": "rich_text_section",
-          							"elements": [
-          								{
-          									"type": "text",
-          									"text": "Affected entity id: "
-          								},
-          								{
-          									"type": "text",
-          									"text": "{{ (_.finding.vulnerability_finding_events|first).get("affected_entity.id") }}"
+          									"text": "{{ (_.finding.vulnerability_finding_events|first).get("object.id") }}"
           								}
           							]
           						},
@@ -138,7 +125,7 @@ workflow:
           					"text": "View all findings",
           					"emoji": true
           				},
-          				"url": "{{ environment().url}}/ui/intent/dynatrace.notebooks/view-query#%7B%22dt.query%22%3A%22fetch%20events%5Cn%2F%2F%20data%20access%5Cn%7C%20filter%20dt.system.bucket%20%3D%3D%20%5C%22default_security_custom_events%5C%22%5Cn%20%20%20%20%20AND%20event.type%20%3D%3D%20%5C%22VULNERABILITY_FINDING_EVENT%5C%22%5Cn%20%20%20%20%20AND%20isNotNull(vulnerable_component.name)%5Cn%7C%20dedup%20%7Baffected_entity.id%2C%20vulnerability.external_id%2C%20vulnerable_component.name%7D%2C%20sort%3A%20%7Btimestamp%20desc%7D%5Cn%2F%2F%20aggregation%20and%20custom%20filtering%5Cn%7C%20sort%20timestamp%20desc%22%2C%22dt.timeframe%22%3A%7B%22from%22%3A%22now()-7d%22%2C%22to%22%3A%22now()%22%7D%2C%22hideInput%22%3Afalse%2C%22sourceApplication%22%3A%22dynatrace.notebooks%22%2C%22title%22%3A%22List%20recent%20vulnerability%20findings%22%2C%22visualization%22%3A%22recordView%22%2C%22visualizationSettings%22%3A%7B%22thresholds%22%3A%5B%5D%2C%22chartSettings%22%3A%7B%22gapPolicy%22%3A%22connect%22%2C%22circleChartSettings%22%3A%7B%22groupingThresholdType%22%3A%22relative%22%2C%22groupingThresholdValue%22%3A0%2C%22valueType%22%3A%22relative%22%7D%2C%22categoryOverrides%22%3A%7B%7D%2C%22categoricalBarChartSettings%22%3A%7B%22categoryAxis%22%3A%22affected_entity.name%22%2C%22categoryAxisLabel%22%3A%22affected_entity.name%22%2C%22valueAxis%22%3A%22vulnerability.risk.score%22%2C%22valueAxisLabel%22%3A%22vulnerability.risk.score%22%7D%2C%22hiddenLegendFields%22%3A%5B%5D%2C%22fieldMapping%22%3A%7B%22timestamp%22%3A%22timestamp%22%2C%22leftAxisValues%22%3A%5B%22vulnerability.risk.score%22%5D%2C%22leftAxisDimensions%22%3A%5B%22account%22%5D%7D%7D%2C%22singleValue%22%3A%7B%22showLabel%22%3Atrue%2C%22label%22%3A%22%22%2C%22prefixIcon%22%3A%22%22%2C%22recordField%22%3A%22timestamp%22%2C%22autoscale%22%3Atrue%2C%22alignment%22%3A%22center%22%2C%22colorThresholdTarget%22%3A%22value%22%7D%2C%22table%22%3A%7B%22rowDensity%22%3A%22condensed%22%2C%22enableSparklines%22%3Afalse%2C%22hiddenColumns%22%3A%5B%5D%2C%22lineWrapIds%22%3A%5B%5D%2C%22firstVisibleRowIndex%22%3A0%2C%22columnWidths%22%3A%7B%7D%7D%2C%22honeycomb%22%3A%7B%22shape%22%3A%22hexagon%22%2C%22legend%22%3A%22auto%22%2C%22colorMode%22%3A%22color-palette%22%2C%22colorPalette%22%3A%22blue%22%2C%22dataMappings%22%3A%7B%22value%22%3A%22vulnerability.risk.score%22%7D%2C%22displayedFields%22%3A%5B%22account%22%5D%7D%2C%22histogram%22%3A%7B%22dataMappings%22%3A%5B%7B%22valueAxis%22%3A%22vulnerability.risk.score%22%2C%22rangeAxis%22%3A%22%22%7D%2C%7B%22valueAxis%22%3A%22activity_id%22%2C%22rangeAxis%22%3A%22%22%7D%2C%7B%22valueAxis%22%3A%22category_uid%22%2C%22rangeAxis%22%3A%22%22%7D%2C%7B%22valueAxis%22%3A%22class_uid%22%2C%22rangeAxis%22%3A%22%22%7D%2C%7B%22valueAxis%22%3A%22severity_id%22%2C%22rangeAxis%22%3A%22%22%7D%2C%7B%22valueAxis%22%3A%22time%22%2C%22rangeAxis%22%3A%22%22%7D%2C%7B%22valueAxis%22%3A%22type_uid%22%2C%22rangeAxis%22%3A%22%22%7D%5D%7D%7D%7D",
+                          "url": "{{ environment().url }}/ui/intent/dynatrace.notebooks/view-query#%7B%22title%22%3A%22List%20recent%20vulnerability%20findings%22%2C%22visualizationSettings%22%3A%7B%22thresholds%22%3A%5B%5D%2C%22chartSettings%22%3A%7B%22gapPolicy%22%3A%22gap%22%2C%22circleChartSettings%22%3A%7B%22groupingThresholdType%22%3A%22relative%22%2C%22groupingThresholdValue%22%3A0%2C%22valueType%22%3A%22relative%22%7D%2C%22categoryOverrides%22%3A%7B%7D%2C%22curve%22%3A%22linear%22%2C%22pointsDisplay%22%3A%22auto%22%2C%22categoricalBarChartSettings%22%3A%7B%22layout%22%3A%22horizontal%22%2C%22categoryAxisTickLayout%22%3A%22horizontal%22%2C%22scale%22%3A%22absolute%22%2C%22groupMode%22%3A%22stacked%22%2C%22colorPaletteMode%22%3A%22multi-color%22%7D%2C%22colorPalette%22%3A%22categorical%22%2C%22valueRepresentation%22%3A%22absolute%22%7D%2C%22singleValue%22%3A%7B%22showLabel%22%3Atrue%2C%22label%22%3A%22%22%2C%22prefixIcon%22%3A%22%22%2C%22autoscale%22%3Atrue%2C%22alignment%22%3A%22center%22%2C%22colorThresholdTarget%22%3A%22value%22%7D%2C%22table%22%3A%7B%22rowDensity%22%3A%22condensed%22%2C%22enableSparklines%22%3Afalse%2C%22hiddenColumns%22%3A%5B%5D%2C%22linewrapEnabled%22%3Afalse%2C%22lineWrapIds%22%3A%5B%5D%2C%22monospacedFontEnabled%22%3Afalse%2C%22monospacedFontColumns%22%3A%5B%5D%2C%22firstVisibleRowIndex%22%3A0%2C%22columnWidths%22%3A%7B%7D%2C%22columnTypeOverrides%22%3A%5B%5D%7D%2C%22honeycomb%22%3A%7B%22shape%22%3A%22hexagon%22%2C%22legend%22%3A%7B%22hidden%22%3Afalse%2C%22position%22%3A%22auto%22%7D%2C%22displayedFields%22%3A%5B%5D%2C%22dataMappings%22%3A%7B%7D%2C%22colorMode%22%3A%22color-palette%22%2C%22colorPalette%22%3A%22categorical%22%7D%2C%22histogram%22%3A%7B%22legend%22%3A%22auto%22%2C%22yAxis%22%3A%7B%22label%22%3A%22Frequency%22%2C%22scale%22%3A%22linear%22%7D%2C%22colorPalette%22%3A%22categorical%22%2C%22dataMappings%22%3A%5B%5D%2C%22variant%22%3A%22single%22%7D%7D%2C%22dt.timeframe%22%3A%7B%22from%22%3A%22now()-7d%22%2C%22to%22%3A%22now()%22%7D%2C%22dt.query%22%3A%22fetch%20events%5Cn%2F%2F%20data%20access%5Cn%7C%20filter%20dt.system.bucket%20%3D%3D%20%5C%22default_security_custom_events%5C%22%5Cn%20%20%20%20%20AND%20event.type%20%3D%3D%20%5C%22VULNERABILITY_FINDING%5C%22%5Cn%20%20%20%20%20AND%20isNotNull(component.name)%5Cn%7C%20dedup%20%7Bobject.id%2C%20vulnerability.id%2C%20component.name%7D%2C%20sort%3A%20%7Btimestamp%20desc%7D%5Cn%2F%2F%20aggregation%20and%20custom%20filtering%5Cn%7C%20sort%20timestamp%20desc%22%2C%22hideInput%22%3Afalse%2C%22sourceApplication%22%3A%22dynatrace.notebooks%22%7D",
           				"action_id": "button-action"
           			}
           		}
@@ -171,41 +158,70 @@ workflow:
       active: true
       input:
         query: >-
+          // The query has a rolling window of 7 days and the last 24hrs.
+
+          // Vulnerability finding events which have already been reported
+
+          // before the current 24hr window will not be reported again.
+
           fetch events, from: now() - 7d
 
-          // data access
-
           | filter dt.system.bucket == "default_security_custom_events"
-               AND event.type == "VULNERABILITY_FINDING_EVENT"
-               AND isNotNull(vulnerable_component.name)
-          | dedup {affected_entity.id, vulnerability.external_id,
-          vulnerable_component.name}, sort: {timestamp asc}
+               AND event.kind == "SECURITY_EVENT"
+               AND event.type == "VULNERABILITY_FINDING"
+               AND isNotNull(component.name)
+               AND dt.security.risk.level == "CRITICAL"
+          // Aggregate vulnerability findings per object.id, vulnerability, 
 
-          // aggregation and custom filtering
-
-          | filter vulnerability.risk.level=="CRITICAL"
+          // component and component version.
 
           | summarize {
                 vulnerable_components_count = count(),
                 vulnerability_finding_events = collectArray(
                   record(
-                    affected_entity.id = affected_entity.id,
-                    affected_entity.name = affected_entity.name,
-                    event.provider_product = event.provider_product,
-                    vulnerable_component.version = vulnerable_component.version,
-                    vulnerable_component.short_name = vulnerable_component.short_name,
-                    vulnerability.risk.level = vulnerability.risk.level,
-                    vulnerability.title = vulnerability.title,
-                    vulnerability.external_id = vulnerability.external_id,
-                    vulnerability.description = vulnerability.description,
-                    scan_time = timestamp
+                    object.id = object.id,
+                    component.name = component.name,
+                    component.version = component.version,
+                    event.provider = event.provider,
+                    dt.security.risk.level = dt.security.risk.level,
+                    vulnerability.id = vulnerability.id,
+                    ingest_time = timestamp
                   )
                 )
-              }, by:{ vulnerability.external_id}
-          | filterOut iAny(vulnerability_finding_events[][scan_time] < now() -
+              }, by:{ object.id, vulnerability.id, component.name, component.version }
+          // Filter out, if this vulnerability for the object and the component 
+
+          // and version was already reported before the last 24 hours.
+
+          // For example, if the same vulnerability was reported multiple times
+
+          // during the last 7 days, don't report it again.
+
+          | filterOut iAny(vulnerability_finding_events[][ingest_time] < now() -
+
           24h)
 
-          | sort vulnerability_finding_events[][scan_time] desc
+          // Expand and deduplicate for repetitive findings if they
+
+          // were reported more than once in the last 24 hours.
+
+          | expand vulnerability_finding_events
+
+          | dedup { vulnerability_finding_events[object.id],
+          vulnerability_finding_events[vulnerability.id],
+          vulnerability_finding_events[component.name],
+          vulnerability_finding_events[component.version] } 
+
+          // Aggregate again to count the unique vulnerable components for each
+          vulnerability.
+
+          | summarize {
+                vulnerable_components_count = count(),
+                vulnerability_finding_events = collectArray(
+                  vulnerability_finding_events
+                )
+              }, by:{ vulnerability.id }
+          | sort vulnerability_finding_events[][ingest_time] desc
       customSampleResult: {}
       position:
         x: 0


### PR DESCRIPTION
This PR updates the security notification workflow samples to be compatible with the events of the new semantic dictionary schema that is rolled out with Dynatrace 1.304:

- jira_tickets_for_critical_vulnerabilities.yaml
- jira_tickets_for_critical_container_vulnerabilities.yaml
- slack_notifications_for_critical_vulnerabilities.yaml
- slack_notifications_for_critical_container_vulnerabilities.yaml