### PR TITLE
RSA-27452 Update queries to security.events

### DIFF
--- a/samples/security/dynatrace vulnerability events/jira_create_ticket_per_host_with_ownership.yaml
+++ b/samples/security/dynatrace vulnerability events/jira_create_ticket_per_host_with_ownership.yaml
@@ -360,9 +360,8 @@ workflow:
       action: dynatrace.automations:execute-dql-query
       input:
         query: >-
-          fetch events, from:now()-60m
-
-          | filter dt.system.bucket=="default_security_events"
+          fetch security.events, from:now()-60m
+          | filter dt.system.bucket=="default_securityevents_builtin"
 
           | filter event.provider=="Dynatrace"
 

--- a/samples/security/dynatrace vulnerability events/ms_teams_send_critical_vulnerabilities_per_affected_entity.yaml
+++ b/samples/security/dynatrace vulnerability events/ms_teams_send_critical_vulnerabilities_per_affected_entity.yaml
@@ -231,9 +231,9 @@ workflow:
           // fetch only recent state reports (reduce the amount of snapshots
           fetched)
 
-          fetch events, from:now()-30m
+          fetch security.events, from:now()-30m
 
-          | filter dt.system.bucket=="default_security_events"
+          | filter dt.system.bucket=="default_securityevents_builtin"
 
           | filter event.provider=="Dynatrace"
 

--- a/samples/security/dynatrace vulnerability events/ocsf_send_critical_vulnerabilities.yaml
+++ b/samples/security/dynatrace vulnerability events/ocsf_send_critical_vulnerabilities.yaml
@@ -170,5 +170,5 @@ workflow:
 
             and (vulnerability.risk.level=="CRITICAL" or
             vulnerability.risk.level=="HIGH")
-          eventType: events
+          eventType: security.events
   schemaVersion: 3

--- a/samples/security/dynatrace vulnerability events/servicenow_create_ticket_per_host_static_assignment.yaml
+++ b/samples/security/dynatrace vulnerability events/servicenow_create_ticket_per_host_static_assignment.yaml
@@ -178,9 +178,9 @@ workflow:
       action: dynatrace.automations:execute-dql-query
       input:
         query: >-
-          fetch events, from:now()-60m
+          fetch security.events, from:now()-60m
 
-          | filter dt.system.bucket=="default_security_events"
+          | filter dt.system.bucket=="default_securityevents_builtin"
 
           | filter event.provider=="Dynatrace"
 

--- a/samples/security/dynatrace vulnerability events/slack_send_critical_vulnerabilities_per_host.yaml
+++ b/samples/security/dynatrace vulnerability events/slack_send_critical_vulnerabilities_per_host.yaml
@@ -74,9 +74,9 @@ workflow:
           // fetch only recent state reports (reduce the amount of snapshots
           fetched)
 
-          fetch events, from:now()-30m
+          fetch security.events, from:now()-30m
 
-          | filter dt.system.bucket=="default_security_events"
+          | filter dt.system.bucket=="default_securityevents_builtin"
 
           | filter event.provider=="Dynatrace"
 

--- a/samples/security/dynatrace vulnerability events/vulnerable products to jira/trigger_workflow.yaml
+++ b/samples/security/dynatrace vulnerability events/vulnerable products to jira/trigger_workflow.yaml
@@ -14,9 +14,10 @@ workflow:
       action: dynatrace.automations:execute-dql-query
       input:
         query: >-
-          fetch events, from:now() - 45m
+          fetch security.events, from:now()-45m
+
             | filter event.provider=="Dynatrace"
-            | filter dt.system.bucket=="default_security_events"
+            | filter dt.system.bucket=="default_securityevents_builtin"
             | filter event.kind == "SECURITY_EVENT"
             | filter event.category == "VULNERABILITY_MANAGEMENT"
             | filter event.type == "VULNERABILITY_STATE_REPORT_EVENT"

--- a/samples/security/external security findings/email_for_critical_security_findings.yaml
+++ b/samples/security/external security findings/email_for_critical_security_findings.yaml
@@ -23,9 +23,9 @@ workflow:
 
           // before the current 24hr window will not be reported again.
 
-          fetch events, from: now() - 7d
+          fetch security.events, from: now() - 7d
 
-          | filter dt.system.bucket == "default_security_custom_events"
+          | filter dt.system.bucket == "default_securityevents"
                AND event.kind == "SECURITY_EVENT"
                AND dt.security.risk.level == "CRITICAL"
                AND isNotNull(object.id) AND isNotNull(object.type)

--- a/samples/security/external security findings/jira_tickets_for_critical_container_vulnerabilities.yaml
+++ b/samples/security/external security findings/jira_tickets_for_critical_container_vulnerabilities.yaml
@@ -27,9 +27,9 @@ workflow:
 
           // before the current 24hr window will not be reported again.
 
-          fetch events, from: now() - 7d
+          fetch security.events, from: now() - 7d
 
-          | filter dt.system.bucket == "default_security_custom_events"
+          | filter dt.system.bucket == "default_securityevents"
               AND event.kind == "SECURITY_EVENT"
               AND object.type == "CONTAINER_IMAGE"
               AND event.type == "VULNERABILITY_FINDING"

--- a/samples/security/external security findings/jira_tickets_for_critical_vulnerabilities.yaml
+++ b/samples/security/external security findings/jira_tickets_for_critical_vulnerabilities.yaml
@@ -27,9 +27,9 @@ workflow:
 
           // before the current 24hr window will not be reported again.
 
-          fetch events, from: now() - 7d
+          fetch security.events, from: now() - 7d
 
-          | filter dt.system.bucket == "default_security_custom_events"
+          | filter dt.system.bucket == "default_securityevents"
                AND event.kind == "SECURITY_EVENT"
                AND event.type == "VULNERABILITY_FINDING"
                AND isNotNull(component.name)

--- a/samples/security/external security findings/readme.md
+++ b/samples/security/external security findings/readme.md
@@ -1,7 +1,3 @@
 # Sample Workflows for Vulnerability Finding Events
-Note: Since the introduction of the Grail security table, up-to-date artifacts are now delivered directly in-product through new integrations.
-As a result, the artifacts in this repository are no longer maintained and will become outdated.
-For further details, see the [Grail security table migration guide](https://docs.dynatrace.com/docs/secure/threat-observability/migration).
-
 This folder contains sample workflows for vulnerability findings ingested into Dynatrace from third-party tools.
 For the overview see the parent [readme.md](../readme.md).

--- a/samples/security/external security findings/slack_notifications_for_critical_container_vulnerabilities.yaml
+++ b/samples/security/external security findings/slack_notifications_for_critical_container_vulnerabilities.yaml
@@ -190,9 +190,9 @@ workflow:
 
           // before the current 24hr window will not be reported again.
 
-          fetch events, from: now() - 7d
+          fetch security.events, from: now() - 7d
 
-          | filter dt.system.bucket == "default_security_custom_events"
+          | filter dt.system.bucket == "default_securityevents"
               AND event.kind == "SECURITY_EVENT"
               AND object.type == "CONTAINER_IMAGE"
               AND event.type == "VULNERABILITY_FINDING"

--- a/samples/security/external security findings/slack_notifications_for_critical_vulnerabilities.yaml
+++ b/samples/security/external security findings/slack_notifications_for_critical_vulnerabilities.yaml
@@ -164,9 +164,9 @@ workflow:
 
           // before the current 24hr window will not be reported again.
 
-          fetch events, from: now() - 7d
+          fetch security.events, from: now() - 7d
 
-          | filter dt.system.bucket == "default_security_custom_events"
+          | filter dt.system.bucket == "default_securityevents"
                AND event.kind == "SECURITY_EVENT"
                AND event.type == "VULNERABILITY_FINDING"
                AND isNotNull(component.name)

--- a/samples/security/readme.md
+++ b/samples/security/readme.md
@@ -15,6 +15,11 @@ You can trigger a workflow in 2 different ways:
 1. Per change event - using the workflow trigger for every new vulnerability event reported on the granularity of the affected entity (for example, vulnerability A per process group B). This approach will trigger immediately as soon as the triggering event appears.
 2. Periodical trigger - using the periodical query for events in the past time period. This approach allows you to perform aggregations and a better deduplication of notifications.
 
+### Security.events table migration
+
+With June 2026 all builtin security events were moved to a separate grail table. Customers are expected to also change the destination of externally ingested events. The samples in this folder use the ´security.events´ table as a datasource.  
+For further information see the [security.events table migration guide](https://docs.dynatrace.com/docs/secure/threat-observability/migration).
+
 ## Sample Workflows for Dynatrace-generated Security Events
 * `ms_teams_send_critical_vulnerabilities_per_affected_entity.yaml` - MS Teams notification for new critical vulnerabilities per affected entity (static channel assignment).
 * `slack_send_critical_vulnerabilities_per_host.yaml` - Slack notification for new critical vulnerabilities aggregated per host (static channel assignment).

--- a/samples/security/readme.md
+++ b/samples/security/readme.md
@@ -17,7 +17,7 @@ You can trigger a workflow in 2 different ways:
 
 ### Security.events table migration
 
-With June 2026 all builtin security events were moved to a separate grail table. Customers are expected to also change the destination of externally ingested events. The samples in this folder use the ´security.events´ table as a datasource.  
+With June 2025 all builtin security events were moved to a separate grail table. Customers are expected to also change the destination of externally ingested events. The samples in this folder use the ´security.events´ table as a datasource.  
 For further information see the [security.events table migration guide](https://docs.dynatrace.com/docs/secure/threat-observability/migration).
 
 ## Sample Workflows for Dynatrace-generated Security Events


### PR DESCRIPTION
Update queries to use security.events table (builtin events of dynatrace appsec will only be available in new table after end of this year).

Please consider that we renamed the buckets in the new table:

- default_security_custom_events (old) -> default_securityevents (Ingested Events)
- default_security_events (old) -> default_securityevents_builtin (DT Builtin Events)
 