### PR TITLE
ServiceNow Basic Open and Close Incident

### DIFF
--- a/samples/ServiceNow Basic Open and Close Incident/Readme.md
+++ b/samples/ServiceNow Basic Open and Close Incident/Readme.md
@@ -10,3 +10,4 @@ The focus of this WF sample is to demonstrate the opening and closing logic for 
 
 All other aspects of the WF are intentionally kept basic (using WF ServiceNow task defaults), to help you get started as quickly as possible after importing this WF. This WF sample can then be expanded further based on your requirements.
 
+![SNOW_logic_close](https://github.com/user-attachments/assets/c9ea4c6e-88f8-4b9d-823d-36eb455ca864)

--- a/samples/ServiceNow Basic Open and Close Incident/Readme.md
+++ b/samples/ServiceNow Basic Open and Close Incident/Readme.md
@@ -1,0 +1,12 @@
+Workflow (WF) to demonstrate basic logic for opening and closing ServiceNow incidents:
+- WF will be triggered on problem open and close. 
+- Task A: Search if SNOW incident already exists in SNOW
+- Task B: If SNOW incident does not exist AND new Problem (event.status = OPEN) ---> create new incident in SNOW
+- Task C: If SNOW incident does exist AND Problem was closed in DT (event.status = CLOSED) ---> resolve incident in SNOW
+
+The focus of this WF sample is to demonstrate the opening and closing logic for ServiceNow incidents with conditional Jinja expressions:
+- If new DT problem opens  ---> create SNOW incident
+- If new DT problem closes ---> resolve SNOW incident
+
+All other aspects of the WF are intentionally kept basic (using WF ServiceNow task defaults), to help you get started as quickly as possible after importing this WF. This WF sample can then be expanded further based on your requirements.
+

--- a/samples/ServiceNow Basic Open and Close Incident/Readme.md
+++ b/samples/ServiceNow Basic Open and Close Incident/Readme.md
@@ -1,7 +1,7 @@
 **Workflow (WF) to demonstrate basic logic for opening and closing ServiceNow incidents:**
 - WF will be triggered on problem open and close. 
 - Task `A`: Search if SNOW incident already exists in SNOW
-- Task `B`: If SNOW incident does not exist AND new Problem (`event.status = OPEN`) ---> create new incident in SNOW
+- Task `B`: If SNOW incident does not exist AND Problem is not closed (`event.status != CLOSED`) ---> create new incident in SNOW
 - Task `C`: If SNOW incident does exist AND Problem was closed in DT (`event.status = CLOSED`) ---> resolve incident in SNOW
 
 The focus of this WF sample is to demonstrate the opening and closing logic for ServiceNow incidents with conditional Jinja expressions:

--- a/samples/ServiceNow Basic Open and Close Incident/Readme.md
+++ b/samples/ServiceNow Basic Open and Close Incident/Readme.md
@@ -1,8 +1,8 @@
-Workflow (WF) to demonstrate basic logic for opening and closing ServiceNow incidents:
+**Workflow (WF) to demonstrate basic logic for opening and closing ServiceNow incidents:**
 - WF will be triggered on problem open and close. 
-- Task A: Search if SNOW incident already exists in SNOW
-- Task B: If SNOW incident does not exist AND new Problem (event.status = OPEN) ---> create new incident in SNOW
-- Task C: If SNOW incident does exist AND Problem was closed in DT (event.status = CLOSED) ---> resolve incident in SNOW
+- Task `A`: Search if SNOW incident already exists in SNOW
+- Task `B`: If SNOW incident does not exist AND new Problem (`event.status = OPEN`) ---> create new incident in SNOW
+- Task `C`: If SNOW incident does exist AND Problem was closed in DT (`event.status = CLOSED`) ---> resolve incident in SNOW
 
 The focus of this WF sample is to demonstrate the opening and closing logic for ServiceNow incidents with conditional Jinja expressions:
 - If new DT problem opens  ---> create SNOW incident

--- a/samples/ServiceNow Basic Open and Close Incident/wf_servicenow_-_basic_open_and_close.json
+++ b/samples/ServiceNow Basic Open and Close Incident/wf_servicenow_-_basic_open_and_close.json
@@ -21,7 +21,7 @@
         "y": 2
       },
       "conditions": {
-        "custom": "{% set search_result_count = result(\"search_incidents\") | length %}\n{% set event_status = event()[\"event.status\"] %}\n{{ search_result_count == 0 and event_status != \"CLOSED\"}}",
+        "custom": "{% set search_result_count = result(\"search_incidents\") | length %}\n{% set event_status = event()[\"event.status\"] %}\n{{ search_result_count == 0 and event_status == \"OPEN\"}}",
         "states": {
           "search_incidents": "OK"
         }

--- a/samples/ServiceNow Basic Open and Close Incident/wf_servicenow_-_basic_open_and_close.json
+++ b/samples/ServiceNow Basic Open and Close Incident/wf_servicenow_-_basic_open_and_close.json
@@ -1,0 +1,108 @@
+{
+  "id": "5aded663-28ed-4612-9258-313964ccb60e",
+  "title": "ServiceNow - Basic Open & Close Incident",
+  "tasks": {
+    "create_incident": {
+      "name": "create_incident",
+      "input": {
+        "caller": "admin",
+        "impact": "3",
+        "urgency": "3",
+        "category": "inquiry",
+        "description": "Event details: {{ event() }}",
+        "subCategory": "internal application",
+        "connectionId": "vu9U3hXa3q0AAAABACNhcHA6ZHluYXRyYWNlLnNlcnZpY2Vub3c6Y29ubmVjdGlvbgAGdGVuYW50AAZ0ZW5hbnQAJGU1NmRjZmEyLTYyM2YtMzBkOC1iODgwLTg2NmQxYmE1MTBhOb7vVN4V2t6t",
+        "correlationId": "DT_{{ event()[\"event.id\"] }}",
+        "shortDescription": "{{ event()[\"event.category\"] }} {{ event()[\"event.name\"] }}"
+      },
+      "action": "dynatrace.servicenow:snow-create-incident",
+      "position": {
+        "x": -1,
+        "y": 2
+      },
+      "conditions": {
+        "custom": "{% set search_result_count = result(\"search_incidents\") | length %}\n{% set event_status = event()[\"event.status\"] %}\n{{ search_result_count == 0 and event_status != \"CLOSED\"}}",
+        "states": {
+          "search_incidents": "OK"
+        }
+      },
+      "description": "Create an incident in ServiceNow",
+      "predecessors": [
+        "search_incidents"
+      ]
+    },
+    "resolve_incident": {
+      "name": "resolve_incident",
+      "input": {
+        "number": "{{ result('search_incidents')[0].number }}",
+        "connectionId": "vu9U3hXa3q0AAAABACNhcHA6ZHluYXRyYWNlLnNlcnZpY2Vub3c6Y29ubmVjdGlvbgAGdGVuYW50AAZ0ZW5hbnQAJGU1NmRjZmEyLTYyM2YtMzBkOC1iODgwLTg2NmQxYmE1MTBhOb7vVN4V2t6t",
+        "resolutionCode": "Closed/Resolved by Caller",
+        "resolutionNotes": "Incident resolved via Dynatrace ServiceNow Workflow"
+      },
+      "action": "dynatrace.servicenow:snow-resolve-incident",
+      "position": {
+        "x": 1,
+        "y": 2
+      },
+      "conditions": {
+        "custom": "{% set search_result_count = result(\"search_incidents\") | length %}\n{% set event_status = event()[\"event.status\"] %}\n{{ search_result_count > 0 and event_status == \"CLOSED\"}}",
+        "states": {
+          "search_incidents": "OK"
+        }
+      },
+      "description": "Resolve an incident in ServiceNow",
+      "predecessors": [
+        "search_incidents"
+      ]
+    },
+    "search_incidents": {
+      "name": "search_incidents",
+      "input": {
+        "connectionId": "vu9U3hXa3q0AAAABACNhcHA6ZHluYXRyYWNlLnNlcnZpY2Vub3c6Y29ubmVjdGlvbgAGdGVuYW50AAZ0ZW5hbnQAJGU1NmRjZmEyLTYyM2YtMzBkOC1iODgwLTg2NmQxYmE1MTBhOb7vVN4V2t6t",
+        "sysparmLimit": "100",
+        "sysparmQuery": "correlation_id=DT_{{ event()[\"event.id\"] }}",
+        "sysparmFields": ""
+      },
+      "action": "dynatrace.servicenow:snow-search-incidents",
+      "position": {
+        "x": 0,
+        "y": 1
+      },
+      "description": "Search for incidents in ServiceNow",
+      "predecessors": []
+    }
+  },
+  "description": "",
+  "actor": "cc3fb42f-a454-4cfd-a034-49d082fb9ca8",
+  "owner": "cc3fb42f-a454-4cfd-a034-49d082fb9ca8",
+  "ownerType": "USER",
+  "isPrivate": true,
+  "trigger": {
+    "eventTrigger": {
+      "isActive": true,
+      "filterQuery": "event.kind == \"DAVIS_PROBLEM\" AND (event.category == \"MONITORING_UNAVAILABLE\" OR event.category == \"AVAILABILITY\" OR event.category == \"ERROR\" OR event.category == \"SLOWDOWN\" OR event.category == \"RESOURCE_CONTENTION\" OR event.category == \"CUSTOM_ALERT\")",
+      "uniqueExpression": "{{ event()[\"event.id\"] }}-{{ \"open\" if event()[\"event.status_transition\"] in (\"CREATED\", \"UPDATED\", \"REOPENED\", \"REFRESHED\") else \"resolved\" }}-{{ event()[\"dt.davis.last_reopen_timestamp\"] }}",
+      "triggerConfiguration": {
+        "type": "davis-problem",
+        "value": {
+          "categories": {
+            "error": true,
+            "custom": true,
+            "resource": true,
+            "slowdown": true,
+            "availability": true,
+            "monitoringUnavailable": true
+          },
+          "entityTags": {},
+          "customFilter": "",
+          "onProblemClose": true
+        }
+      }
+    }
+  },
+  "schemaVersion": 3,
+  "result": null,
+  "input": {},
+  "hourlyExecutionLimit": 1000,
+  "type": "STANDARD"
+}


### PR DESCRIPTION
Workflow (WF) to demonstrate basic logic for opening and closing ServiceNow incidents:
- WF will be triggered on problem open and close. 
- Task `A`: Search if SNOW incident already exists in SNOW
- Task `B`: If SNOW incident does not exist AND new Problem (`event.status = OPEN`) ---> create new incident in SNOW
- Task `C`: If SNOW incident does exist AND Problem was closed in DT (`event.status = CLOSED`) ---> resolve incident in SNOW

The focus of this WF sample is to demonstrate the opening and closing logic for ServiceNow incidents with conditional Jinja expressions:
- If new DT problem opens  ---> create SNOW incident
- If new DT problem closes ---> resolve SNOW incident

All other aspects of the WF are intentionally kept basic (using WF ServiceNow task defaults), to help you get started as quickly as possible after importing this WF. This WF sample can then be expanded further based on your requirements.

![SNOW_logic_close](https://github.com/user-attachments/assets/9f565c5e-e193-43c5-8e9c-4ba925b97174)
